### PR TITLE
Add missing secrets import for CryptoSuite

### DIFF
--- a/zeta_frp_suite (1).py
+++ b/zeta_frp_suite (1).py
@@ -25,6 +25,7 @@ import logging
 import threading
 import hashlib
 import random
+import secrets
 import re
 import tempfile
 import socket


### PR DESCRIPTION
### Motivation
- Prevent `NameError` in cryptographic fallback code because `secrets` was not imported and is used by `CryptoSuite`.
- Ensure `CryptoSuite.generate_key()` and the XOR fallback functions can run without runtime errors.

### Description
- Add `import secrets` alongside the other standard library imports in `zeta_frp_suite (1).py`.
- No functional changes to `CryptoSuite`; it continues to use `secrets.token_bytes` in `generate_key` and `_xor_encrypt`.

### Testing
- Executed an inline import and invocation script that loads the module and runs `CryptoSuite.generate_key()` and `CryptoSuite._xor_encrypt(b'test', key)` which completed successfully and printed lengths for the key and ciphertext.
- The test exited with code 0 and did not raise a `NameError`, confirming the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c61fb38d0832bb6a4b4f7dafacad2)