### PR TITLE
Disallow silent XOR AES fallback — add `Config.ALLOW_INSECURE_CRYPTO` and raise clear error when crypto backend missing

### DIFF
--- a/zeta_frp_suite (1).py
+++ b/zeta_frp_suite (1).py
@@ -99,6 +99,9 @@ class Config:
     ENABLE_AUTO_BACKUP = True
     ENABLE_MONITORING = True
     ENABLE_ANALYTICS = True
+
+    # Crypto
+    ALLOW_INSECURE_CRYPTO = False
     
     @classmethod
     def setup(cls):
@@ -178,7 +181,12 @@ class CryptoSuite:
     def encrypt_aes(data: bytes, key: bytes) -> bytes:
         """AES encryption"""
         if not CRYPTO_AVAILABLE:
-            return CryptoSuite._xor_encrypt(data, key)
+            if Config.ALLOW_INSECURE_CRYPTO:
+                return CryptoSuite._xor_encrypt(data, key)
+            raise RuntimeError(
+                "Cryptography backend unavailable. Install pycryptodome or set "
+                "Config.ALLOW_INSECURE_CRYPTO = True to allow insecure XOR fallback."
+            )
         
         try:
             cipher = AES.new(key[:32], AES.MODE_GCM)
@@ -191,7 +199,12 @@ class CryptoSuite:
     def decrypt_aes(data: bytes, key: bytes) -> bytes:
         """AES decryption"""
         if not CRYPTO_AVAILABLE:
-            return CryptoSuite._xor_decrypt(data, key)
+            if Config.ALLOW_INSECURE_CRYPTO:
+                return CryptoSuite._xor_decrypt(data, key)
+            raise RuntimeError(
+                "Cryptography backend unavailable. Install pycryptodome or set "
+                "Config.ALLOW_INSECURE_CRYPTO = True to allow insecure XOR fallback."
+            )
         
         try:
             nonce = data[:16]


### PR DESCRIPTION
### Motivation
- Prevent silent use of an insecure XOR fallback when the cryptography backend is unavailable.
- Make the danger explicit by failing fast with a clear error instead of returning insecure ciphertext.
- Provide an explicit opt-in for insecure behavior via a configuration flag. 

### Description
- Add `Config.ALLOW_INSECURE_CRYPTO = False` to central configuration to control insecure fallback usage.  
- Update `CryptoSuite.encrypt_aes()` to raise a `RuntimeError` with a clear message when `CRYPTO_AVAILABLE` is `False`, unless `Config.ALLOW_INSECURE_CRYPTO` is `True`.  
- Update `CryptoSuite.decrypt_aes()` to mirror the same behavior for decryption.  
- Preserve the existing XOR fallback code but require explicit opt-in to use it; existing AES code still falls back to XOR only on runtime exceptions during crypto operations.

### Testing
- No automated tests were executed as part of this change.  
- The change was applied and committed to the repository without running unit or integration tests.  
- Manual/verbal verification: code compiles and import paths unaffected (no automated runs).  
- Recommend adding unit tests to exercise both branches (`CRYPTO_AVAILABLE` on/off and `ALLOW_INSECURE_CRYPTO` true/false) in follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c6256e048832bbd746761f7e9b68f)