### PR TITLE
Add proprietary LICENSE and ownership notices

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Proprietary License
+
+Copyright (c) 2024 Roach Labs. All rights reserved.
+
+This software and accompanying materials are proprietary and confidential to
+Roach Labs. No license or rights are granted to use, copy, modify, distribute,
+publicly display, or create derivative works of this software without an
+express written agreement signed by Roach Labs.
+
+Unauthorized use, reproduction, or distribution of this software, in whole or
+in part, is strictly prohibited and may result in civil and criminal penalties.

--- a/zeta_frp_suite (1).py
+++ b/zeta_frp_suite (1).py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 """
-███████╗███████╗████████╗ █████╗     ███████╗██████╗ ██████╗ 
+███████╗███████╗████████╗ █████╗     ███████╗██████╗ ██████╗
 ██╔════╝██╔════╝╚══██╔══╝██╔══██╗    ██╔════╝██╔══██╗██╔══██╗
 █████╗  █████╗     ██║   ███████║    █████╗  ██████╔╝██████╔╝
 ██╔══╝  ██╔════╝     ██║   ██╔══██║    ██╔══╝  ██╔══██╗██╔══██╗
@@ -12,6 +12,10 @@ from __future__ import annotations
 ZETA FRP SUITE v6.0.0 - ULTIMATE AUTOMATED EDITION
 Complete Android Toolkit - 200+ FULLY AUTOMATED FEATURES
 All operations work out-of-the-box with ZERO manual setup!
+
+Copyright (c) 2024 Roach Labs. All rights reserved.
+Made by James Michael Roach Jr.
+Proprietary and confidential. Unauthorized use or distribution is prohibited.
 """
 
 import sys
@@ -1635,9 +1639,11 @@ class CLI:
 ╔══════════════════════════════════════════════════════════════╗
 ║  ZETA FRP SUITE v{Config.VERSION} - {Config.CODENAME}                    ║
 ║  Ultimate Android Toolkit - {features_count}+ Automated Features      ║
+║  Owner: Roach Labs | Made by James Michael Roach Jr.                  ║
 ╚══════════════════════════════════════════════════════════════╝
 
 ✨ All features work automatically - zero manual setup required!
+🔒 Proprietary software owned by Roach Labs.
 
 Type 'help' to see all available commands.
 """
@@ -1919,6 +1925,10 @@ Type 'help' to see all available commands.
 ║                   ZETA FRP SUITE - HELP                      ║
 ╚══════════════════════════════════════════════════════════════╝
 
+Owner: Roach Labs
+Made by James Michael Roach Jr.
+Proprietary software. Unauthorized use or distribution is prohibited.
+
 📋 AVAILABLE COMMANDS:
 
 DEVICE MANAGEMENT:
@@ -1982,7 +1992,10 @@ SYSTEM:
 def main():
     """Main entry point"""
     parser = argparse.ArgumentParser(
-        description=f"Zeta FRP Suite v{Config.VERSION} - Ultimate Android Toolkit"
+        description=(
+            f"Zeta FRP Suite v{Config.VERSION} - Ultimate Android Toolkit "
+            "(Owner: Roach Labs, Made by James Michael Roach Jr.)"
+        )
     )
     
     parser.add_argument('--version', action='store_true', help='Show version')
@@ -1996,6 +2009,7 @@ def main():
     if args.version:
         print(f"Zeta FRP Suite v{Config.VERSION} - {Config.CODENAME}")
         print("200+ Automated Features")
+        print("Owner: Roach Labs | Made by James Michael Roach Jr.")
         return
     
     if args.devices:


### PR DESCRIPTION
### Motivation
- Mark the repository and distributed binary as proprietary and attribute ownership to Roach Labs. 
- Ensure the codebase and user-facing messaging clearly name the author as `James Michael Roach Jr.`. 
- Make ownership and confidentiality visible in the module header and interactive help so end users see the proprietor/legal notice. 

### Description
- Add a top-level `LICENSE` file containing proprietary terms that name `Roach Labs` as owner. 
- Update the module docstring/header in `zeta_frp_suite (1).py` to include copyright, the author line `Made by James Michael Roach Jr.`, and a short proprietary notice. 
- Update the interactive banner (`_print_banner`), help text (`_cmd_help`), CLI `argparse` description, and `--version` output in `zeta_frp_suite (1).py` to surface the owner/author and proprietary notice. 

### Testing
- No automated tests were executed for this change. 
- No unit tests or CI runs were triggered as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c62a79330832bac507e1856d93e89)