### PR TITLE
Require Terms & Conditions acceptance on CLI and GUI startup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+VOID SUITE PROPRIETARY LICENSE
+
+Copyright (c) 2024 Roach Labs.
+All rights reserved.
+
+Owner: Roach Labs
+Author: James Michael Roach Jr.
+
+Permission is hereby granted to use this software solely for internal purposes
+authorized by Roach Labs. This software and all associated documentation are
+proprietary and confidential. You may not copy, modify, sublicense, publish,
+transmit, distribute, or disclose any portion of this software without prior
+written permission from Roach Labs.
+
+THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. IN NO EVENT SHALL
+ROACH LABS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT, OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "void-suite"
+version = "6.0.0"
+description = "Void Suite - Android toolkit"
+requires-python = ">=3.9"
+
+[project.scripts]
+void = "void.main:main"

--- a/void.py
+++ b/void.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""
+Void launcher (compatibility entry point).
+
+PROPRIETARY SOFTWARE
+Copyright (c) 2024 Roach Labs. All rights reserved.
+Made by James Michael Roach Jr.
+Unauthorized copying, modification, distribution, or disclosure is prohibited.
+"""
+
+from void.main import main
+
+
+if __name__ == "__main__":
+    main()

--- a/void/__init__.py
+++ b/void/__init__.py
@@ -1,0 +1,6 @@
+"""Void package."""
+
+from .config import Config
+from .main import main
+
+__all__ = ["Config", "main"]

--- a/void/__main__.py
+++ b/void/__main__.py
@@ -1,0 +1,5 @@
+from .main import main
+
+
+if __name__ == "__main__":
+    main()

--- a/void/cli.py
+++ b/void/cli.py
@@ -1,0 +1,463 @@
+"""
+VOID CLI
+
+PROPRIETARY SOFTWARE
+Copyright (c) 2024 Roach Labs. All rights reserved.
+Made by James Michael Roach Jr.
+Unauthorized copying, modification, distribution, or disclosure is prohibited.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from .config import Config
+from .core import (
+    AppManager,
+    AutoBackup,
+    DataRecovery,
+    DeviceDetector,
+    FileManager,
+    FRPEngine,
+    LogcatViewer,
+    PerformanceAnalyzer,
+    ReportGenerator,
+    ScreenCapture,
+    SystemTweaker,
+    db,
+    monitor,
+)
+
+try:
+    from rich.console import Console
+    from rich.table import Table
+    RICH_AVAILABLE = True
+except ImportError:
+    RICH_AVAILABLE = False
+
+
+class CLI:
+    """Enhanced CLI with all features."""
+
+    def __init__(self):
+        self.console = Console() if RICH_AVAILABLE else None
+        self.engine = FRPEngine()
+        self.logcat = LogcatViewer()
+
+        # Start monitoring
+        monitor.start()
+
+    def run(self) -> None:
+        """Run CLI."""
+        self._print_banner()
+
+        while True:
+            try:
+                cmd = input("\nvoid> ").strip()
+                if not cmd:
+                    continue
+
+                parts = cmd.split()
+                command = parts[0].lower()
+                args = parts[1:]
+
+                # Route commands
+                commands = {
+                    'devices': self._cmd_devices,
+                    'info': lambda: self._cmd_info(args),
+                    'summary': self._cmd_summary,
+                    'backup': lambda: self._cmd_backup(args),
+                    'screenshot': lambda: self._cmd_screenshot(args),
+                    'apps': lambda: self._cmd_apps(args),
+                    'files': lambda: self._cmd_files(args),
+                    'analyze': lambda: self._cmd_analyze(args),
+                    'recover': lambda: self._cmd_recover(args),
+                    'tweak': lambda: self._cmd_tweak(args),
+                    'report': lambda: self._cmd_report(args),
+                    'stats': self._cmd_stats,
+                    'monitor': self._cmd_monitor,
+                    'logcat': lambda: self._cmd_logcat(args),
+                    'execute': lambda: self._cmd_execute(args),
+                    'help': self._cmd_help,
+                    'exit': lambda: exit(0)
+                }
+
+                if command in commands:
+                    commands[command]()
+                else:
+                    print(f"Unknown command: {command}")
+
+            except KeyboardInterrupt:
+                print("\nUse 'exit' to quit")
+            except Exception as exc:
+                print(f"Error: {exc}")
+
+    def _print_banner(self) -> None:
+        """Print banner."""
+        features_count = 200  # Total automated features
+
+        banner = f"""
+╔══════════════════════════════════════════════════════════════╗
+║  VOID v{Config.VERSION} - {Config.CODENAME}                             ║
+║  Ultimate Android Toolkit - {features_count}+ Automated Features      ║
+╚══════════════════════════════════════════════════════════════╝
+
+✨ All features work automatically - zero manual setup required!
+
+Type 'help' to see all available commands.
+"""
+        print(banner)
+
+    def _cmd_devices(self) -> None:
+        """List devices."""
+        devices = DeviceDetector.detect_all()
+
+        if not devices:
+            print("❌ No devices detected")
+            return
+
+        if self.console:
+            table = Table(title="Connected Devices")
+            table.add_column("ID", style="cyan")
+            table.add_column("Mode", style="green")
+            table.add_column("Manufacturer", style="yellow")
+            table.add_column("Model", style="blue")
+            table.add_column("Android", style="magenta")
+
+            for device in devices:
+                table.add_row(
+                    device.get('id', 'Unknown'),
+                    device.get('mode', 'Unknown'),
+                    device.get('manufacturer', 'Unknown'),
+                    device.get('model', 'Unknown'),
+                    device.get('android_version', 'Unknown')
+                )
+
+            self.console.print(table)
+        else:
+            print("\n📱 Connected Devices:")
+            for device in devices:
+                print(f"  • {device.get('id')} - {device.get('manufacturer')} {device.get('model')}")
+
+    def _cmd_backup(self, args: List[str]) -> None:
+        """Create backup."""
+        if len(args) < 1:
+            print("Usage: backup <device_id>")
+            return
+
+        result = AutoBackup.create_backup(args[0])
+        if result['success']:
+            print(f"✅ Backup created: {result['backup_name']}")
+            print(f"   Items: {', '.join(result['items'])}")
+            print(f"   Size: {result['size']:,} bytes")
+        else:
+            print("❌ Backup failed")
+
+    def _cmd_screenshot(self, args: List[str]) -> None:
+        """Take screenshot."""
+        if len(args) < 1:
+            print("Usage: screenshot <device_id>")
+            return
+
+        result = ScreenCapture.take_screenshot(args[0])
+        if result['success']:
+            print(f"✅ Screenshot saved: {result['path']}")
+        else:
+            print("❌ Screenshot failed")
+
+    def _cmd_apps(self, args: List[str]) -> None:
+        """List apps."""
+        if len(args) < 1:
+            print("Usage: apps <device_id> [system|user|all]")
+            return
+
+        filter_type = args[1] if len(args) > 1 else 'all'
+        apps = AppManager.list_apps(args[0], filter_type)
+
+        print(f"\n📦 {filter_type.title()} Apps ({len(apps)}):")
+        for app in apps[:20]:
+            print(f"  • {app['package']}")
+
+        if len(apps) > 20:
+            print(f"  ... and {len(apps) - 20} more")
+
+    def _cmd_info(self, args: List[str]) -> None:
+        """Show device info."""
+        if len(args) < 1:
+            print("Usage: info <device_id>")
+            return
+
+        devices = DeviceDetector.detect_all()
+        device = next((d for d in devices if d['id'] == args[0]), None)
+
+        if device:
+            print(f"\n📱 Device Information: {args[0]}\n")
+            for key, value in device.items():
+                if not isinstance(value, dict):
+                    print(f"  {key.replace('_', ' ').title()}: {value}")
+        else:
+            print("❌ Device not found")
+
+    def _cmd_summary(self) -> None:
+        """Show a short device summary."""
+        devices = DeviceDetector.detect_all()
+        if not devices:
+            print("❌ No devices detected")
+            return
+
+        print("\n📋 Device Summary\n")
+        for device in devices:
+            device_id = device.get('id', 'Unknown')
+            model = device.get('model', 'Unknown')
+            brand = device.get('brand', 'Unknown')
+            android = device.get('android_version', 'Unknown')
+            security = device.get('security_patch', 'Unknown')
+            reachable = "Yes" if device.get("reachable") else "No"
+            print(f"• {device_id} — {brand} {model} | Android {android} | Patch {security} | Reachable: {reachable}")
+
+    def _cmd_analyze(self, args: List[str]) -> None:
+        """Analyze device."""
+        if len(args) < 1:
+            print("Usage: analyze <device_id>")
+            return
+
+        print("🔍 Analyzing device...")
+        result = PerformanceAnalyzer.analyze(args[0])
+
+        print("\n📊 Performance Analysis:\n")
+        for key, value in result.items():
+            if not isinstance(value, (dict, list)):
+                print(f"  {key.replace('_', ' ').title()}: {value}")
+
+    def _cmd_recover(self, args: List[str]) -> None:
+        """Recover data."""
+        if len(args) < 2:
+            print("Usage: recover <device_id> <contacts|sms>")
+            return
+
+        device_id, data_type = args[0], args[1]
+
+        print(f"💾 Recovering {data_type}...")
+
+        if data_type == 'contacts':
+            result = DataRecovery.recover_contacts(device_id)
+        elif data_type == 'sms':
+            result = DataRecovery.recover_sms(device_id)
+        else:
+            print("❌ Unknown data type")
+            return
+
+        if result['success']:
+            print(f"✅ Recovered {result['count']} items")
+            print(f"   Saved to: {result.get('json_path') or result.get('path')}")
+        else:
+            print("❌ Recovery failed")
+
+    def _cmd_tweak(self, args: List[str]) -> None:
+        """System tweaks."""
+        if len(args) < 3:
+            print("Usage: tweak <device_id> <dpi|animation|timeout> <value>")
+            return
+
+        device_id, tweak_type, value = args[0], args[1], args[2]
+
+        if tweak_type == 'dpi':
+            success = SystemTweaker.set_dpi(device_id, int(value))
+        elif tweak_type == 'animation':
+            success = SystemTweaker.set_animation_scale(device_id, float(value))
+        elif tweak_type == 'timeout':
+            success = SystemTweaker.set_screen_timeout(device_id, int(value))
+        else:
+            print("❌ Unknown tweak type")
+            return
+
+        if success:
+            print(f"✅ {tweak_type.title()} updated")
+        else:
+            print("❌ Tweak failed")
+
+    def _cmd_report(self, args: List[str]) -> None:
+        """Generate report."""
+        if len(args) < 1:
+            print("Usage: report <device_id>")
+            return
+
+        print("📄 Generating report...")
+        result = ReportGenerator.generate_device_report(args[0])
+
+        if result['success']:
+            print(f"✅ Report generated: {result['report_name']}")
+            print(f"   HTML: {result['html_path']}")
+        else:
+            print("❌ Report generation failed")
+
+    def _cmd_stats(self) -> None:
+        """Show statistics."""
+        stats = db.get_statistics()
+
+        print("\n📊 VOID STATISTICS\n")
+        print(f"  Total Devices: {stats['total_devices']}")
+        print(f"  Total Logs: {stats['total_logs']}")
+        print(f"  Total Backups: {stats['total_backups']}")
+        print(f"  Methods Tracked: {stats['total_methods']}")
+
+        if stats.get('top_methods'):
+            print("\n  Top Methods:")
+            for method in stats['top_methods']:
+                rate = (method['success_count'] / method['total_count'] * 100) if method['total_count'] > 0 else 0
+                print(f"    • {method['name']}: {rate:.1f}% ({method['success_count']}/{method['total_count']})")
+
+    def _cmd_monitor(self) -> None:
+        """Show system monitor."""
+        stats = monitor.get_stats()
+
+        if stats:
+            print("\n🖥️  SYSTEM MONITOR\n")
+            print(f"  CPU: {stats.get('cpu_percent', 0):.1f}%")
+            print(f"  Memory: {stats.get('memory_percent', 0):.1f}%")
+            print(f"  Disk: {stats.get('disk_usage', 0):.1f}%")
+        else:
+            print("❌ Monitoring not available (install psutil)")
+
+    def _cmd_logcat(self, args: List[str]) -> None:
+        """Start logcat."""
+        if len(args) < 1:
+            print("Usage: logcat <device_id> [filter_tag]")
+            return
+
+        device_id = args[0]
+        filter_tag = args[1] if len(args) > 1 else None
+
+        print("📜 Starting logcat (Ctrl+C to stop)...")
+        self.logcat.start(device_id, filter_tag)
+
+        try:
+            while True:
+                line = self.logcat.read_line()
+                if line:
+                    print(line.strip())
+        except KeyboardInterrupt:
+            self.logcat.stop()
+            print("\n📜 Logcat stopped")
+
+    def _cmd_execute(self, args: List[str]) -> None:
+        """Execute FRP method."""
+        if len(args) < 2:
+            print("Usage: execute <method> <device_id>")
+            return
+
+        method_name, device_id = args[0], args[1]
+
+        print(f"⚡ Executing {method_name}...")
+
+        if method_name not in self.engine.methods:
+            print(f"❌ Unknown method: {method_name}")
+            return
+
+        result = self.engine.methods[method_name](device_id)
+
+        if result['success']:
+            print(f"✅ Success: {result['message']}")
+        else:
+            print(f"❌ Failed: {result.get('error', result['message'])}")
+
+    def _cmd_files(self, args: List[str]) -> None:
+        """File operations."""
+        if len(args) < 2:
+            print("Usage: files <device_id> <list|pull|push> [path]")
+            return
+
+        device_id, operation = args[0], args[1]
+
+        if operation == 'list':
+            path = args[2] if len(args) > 2 else '/sdcard'
+            files = FileManager.list_files(device_id, path)
+
+            print(f"\n📁 Files in {path}:\n")
+            for file in files[:20]:
+                print(f"  {file['permissions']} {file['size']:>10} {file['date']:>20} {file['name']}")
+
+            if len(files) > 20:
+                print(f"\n  ... and {len(files) - 20} more")
+
+        elif operation == 'pull':
+            if len(args) < 3:
+                print("Usage: files <device_id> pull <remote_path>")
+                return
+
+            result = FileManager.pull_file(device_id, args[2])
+            if result['success']:
+                print(f"✅ File pulled: {result['path']}")
+            else:
+                print("❌ Pull failed")
+
+        else:
+            print("❌ Unknown operation")
+
+    def _cmd_help(self) -> None:
+        """Show help."""
+        help_text = """
+╔══════════════════════════════════════════════════════════════╗
+║                   VOID - HELP                                ║
+╚══════════════════════════════════════════════════════════════╝
+
+📋 AVAILABLE COMMANDS:
+
+DEVICE MANAGEMENT:
+  devices                          - List all connected devices
+  info <device_id>                 - Show detailed device info
+  summary                          - Show a short device summary
+  
+BACKUP & DATA:
+  backup <device_id>               - Create automated backup
+  recover <device_id> <type>       - Recover data (contacts/sms)
+  screenshot <device_id>           - Take screenshot
+  
+APP MANAGEMENT:
+  apps <device_id> [filter]        - List apps (system/user/all)
+  
+FILE OPERATIONS:
+  files <device_id> list [path]    - List files
+  files <device_id> pull <path>    - Pull file from device
+  
+ANALYSIS:
+  analyze <device_id>              - Performance analysis
+  report <device_id>               - Generate full report
+  logcat <device_id> [tag]         - View real-time logs
+  
+TWEAKS:
+  tweak <device_id> <type> <value> - System tweaks
+    Types: dpi, animation, timeout
+  
+FRP BYPASS:
+  execute <method> <device_id>     - Execute bypass method
+    Methods: adb_shell_reset, fastboot_erase, etc.
+  
+SYSTEM:
+  stats                            - Show suite statistics
+  monitor                          - Show system monitor
+  help                             - Show this help
+  exit                             - Exit suite
+
+🎯 EXAMPLES:
+
+  void> devices
+  void> info emulator-5554
+  void> summary
+  void> backup emulator-5554
+  void> screenshot emulator-5554
+  void> apps emulator-5554 user
+  void> analyze emulator-5554
+  void> recover emulator-5554 contacts
+  void> tweak emulator-5554 dpi 320
+  void> report emulator-5554
+  void> execute adb_shell_reset emulator-5554
+
+💡 TIP: All commands work automatically with no setup required!
+
+╚══════════════════════════════════════════════════════════════╝
+"""
+        print(help_text)
+
+
+__all__ = ["CLI", "RICH_AVAILABLE"]

--- a/void/config.py
+++ b/void/config.py
@@ -1,0 +1,63 @@
+"""
+VOID CONFIGURATION
+
+PROPRIETARY SOFTWARE
+Copyright (c) 2024 Roach Labs. All rights reserved.
+Made by James Michael Roach Jr.
+Unauthorized copying, modification, distribution, or disclosure is prohibited.
+"""
+
+from pathlib import Path
+
+
+class Config:
+    """Configuration constants."""
+
+    VERSION = "6.0.0"
+    CODENAME = "AUTOMATION"
+    APP_NAME = "Void"
+
+    # Timeouts
+    TIMEOUT_SHORT = 5
+    TIMEOUT_MEDIUM = 30
+    TIMEOUT_LONG = 300
+
+    # Paths
+    BASE_DIR = Path.home() / ".void"
+    DB_PATH = BASE_DIR / "void.db"
+    LOG_DIR = BASE_DIR / "logs"
+    BACKUP_DIR = BASE_DIR / "backups"
+    EXPORTS_DIR = BASE_DIR / "exports"
+    CACHE_DIR = BASE_DIR / "cache"
+    REPORTS_DIR = BASE_DIR / "reports"
+    MONITOR_DIR = BASE_DIR / "monitoring"
+    SCRIPTS_DIR = BASE_DIR / "scripts"
+
+    # Security
+    MAX_INPUT_LENGTH = 256
+
+    # Features
+    ENABLE_AUTO_BACKUP = True
+    ENABLE_MONITORING = True
+    ENABLE_ANALYTICS = True
+
+    # Crypto
+    ALLOW_INSECURE_CRYPTO = False
+
+    @classmethod
+    def setup(cls) -> None:
+        """Create necessary directories."""
+        for path in [
+            cls.BASE_DIR,
+            cls.LOG_DIR,
+            cls.BACKUP_DIR,
+            cls.EXPORTS_DIR,
+            cls.CACHE_DIR,
+            cls.REPORTS_DIR,
+            cls.MONITOR_DIR,
+            cls.SCRIPTS_DIR,
+        ]:
+            path.mkdir(parents=True, exist_ok=True)
+
+
+Config.setup()

--- a/void/core.py
+++ b/void/core.py
@@ -2,20 +2,25 @@
 from __future__ import annotations
 
 """
-██╗   ██╗ ██████╗ ██╗██████╗ 
+██╗   ██╗ ██████╗ ██╗██████╗
 ██║   ██║██╔═══██╗██║██╔══██╗
 ██║   ██║██║   ██║██║██║  ██║
 ╚██╗ ██╔╝██║   ██║██║██║  ██║
  ╚████╔╝ ╚██████╔╝██║██████╔╝
   ╚═══╝   ╚═════╝ ╚═╝╚═════╝
 
-VOID FRP SUITE v6.0.0 - ULTIMATE AUTOMATED EDITION
+VOID v6.0.0 - ULTIMATE AUTOMATED EDITION
 Complete Android Toolkit - 200+ FULLY AUTOMATED FEATURES
 All operations work out-of-the-box with ZERO manual setup!
+
+PROPRIETARY SOFTWARE
+Copyright (c) 2024 Roach Labs. All rights reserved.
+Made by James Michael Roach Jr.
+Unauthorized copying, modification, distribution, or disclosure is prohibited.
 """
 
-import sys
-import os
+# Proprietary notice: all sections in this file are confidential to Roach Labs.
+
 import json
 import time
 import sqlite3
@@ -25,13 +30,11 @@ import logging
 import threading
 import hashlib
 import random
-import secrets
 import re
 import tempfile
 import socket
 import urllib.request
 import urllib.parse
-import argparse
 import queue
 import zipfile
 import xml.etree.ElementTree as ET
@@ -40,79 +43,20 @@ from pathlib import Path
 from contextlib import contextmanager
 from typing import Dict, List, Optional, Tuple, Any, Set
 
-# Optional imports with graceful fallbacks
+from .config import Config
+from .crypto import CryptoSuite
+
 try:
     from rich.console import Console
-    from rich.table import Table
-    from rich.panel import Panel
-    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
-    from rich.tree import Tree
-    from rich.live import Live
     RICH_AVAILABLE = True
 except ImportError:
     RICH_AVAILABLE = False
-
-try:
-    from Crypto.Cipher import AES, PKCS1_OAEP
-    from Crypto.PublicKey import RSA
-    from Crypto.Random import get_random_bytes
-    from Crypto.Util.Padding import pad, unpad
-    from Crypto.Protocol.KDF import PBKDF2
-    CRYPTO_AVAILABLE = True
-except ImportError:
-    CRYPTO_AVAILABLE = False
 
 try:
     import psutil
     PSUTIL_AVAILABLE = True
 except ImportError:
     PSUTIL_AVAILABLE = False
-
-# ==========================================
-# CONFIGURATION
-# ==========================================
-
-class Config:
-    """Configuration constants"""
-    VERSION = "6.0.0"
-    CODENAME = "AUTOMATION"
-    
-    # Timeouts
-    TIMEOUT_SHORT = 5
-    TIMEOUT_MEDIUM = 30
-    TIMEOUT_LONG = 300
-    
-    # Paths
-    BASE_DIR = Path.home() / ".void_frp_suite"
-    DB_PATH = BASE_DIR / "void.db"
-    LOG_DIR = BASE_DIR / "logs"
-    BACKUP_DIR = BASE_DIR / "backups"
-    EXPORTS_DIR = BASE_DIR / "exports"
-    CACHE_DIR = BASE_DIR / "cache"
-    REPORTS_DIR = BASE_DIR / "reports"
-    MONITOR_DIR = BASE_DIR / "monitoring"
-    SCRIPTS_DIR = BASE_DIR / "scripts"
-    
-    # Security
-    MAX_INPUT_LENGTH = 256
-    
-    # Features
-    ENABLE_AUTO_BACKUP = True
-    ENABLE_MONITORING = True
-    ENABLE_ANALYTICS = True
-
-    # Crypto
-    ALLOW_INSECURE_CRYPTO = False
-    
-    @classmethod
-    def setup(cls):
-        """Create necessary directories"""
-        for path in [cls.BASE_DIR, cls.LOG_DIR, cls.BACKUP_DIR, 
-                     cls.EXPORTS_DIR, cls.CACHE_DIR, cls.REPORTS_DIR,
-                     cls.MONITOR_DIR, cls.SCRIPTS_DIR]:
-            path.mkdir(parents=True, exist_ok=True)
-
-Config.setup()
 
 # ==========================================
 # UTILITIES
@@ -164,76 +108,6 @@ class NetworkTools:
             return True
         except:
             return False
-
-class CryptoSuite:
-    """Cryptographic operations"""
-    
-    @staticmethod
-    def hash_sha256(data: bytes) -> str:
-        """SHA-256 hash"""
-        return hashlib.sha256(data).hexdigest()
-    
-    @staticmethod
-    def generate_key(length: int = 32) -> bytes:
-        """Generate random key"""
-        return secrets.token_bytes(length)
-    
-    @staticmethod
-    def encrypt_aes(data: bytes, key: bytes) -> bytes:
-        """AES encryption"""
-        if not CRYPTO_AVAILABLE:
-            if Config.ALLOW_INSECURE_CRYPTO:
-                return CryptoSuite._xor_encrypt(data, key)
-            raise RuntimeError(
-                "Cryptography backend unavailable. Install pycryptodome or set "
-                "Config.ALLOW_INSECURE_CRYPTO = True to allow insecure XOR fallback."
-            )
-        
-        try:
-            cipher = AES.new(key[:32], AES.MODE_GCM)
-            ciphertext, tag = cipher.encrypt_and_digest(data)
-            return cipher.nonce + tag + ciphertext
-        except:
-            return CryptoSuite._xor_encrypt(data, key)
-    
-    @staticmethod
-    def decrypt_aes(data: bytes, key: bytes) -> bytes:
-        """AES decryption"""
-        if not CRYPTO_AVAILABLE:
-            if Config.ALLOW_INSECURE_CRYPTO:
-                return CryptoSuite._xor_decrypt(data, key)
-            raise RuntimeError(
-                "Cryptography backend unavailable. Install pycryptodome or set "
-                "Config.ALLOW_INSECURE_CRYPTO = True to allow insecure XOR fallback."
-            )
-        
-        try:
-            nonce = data[:16]
-            tag = data[16:32]
-            ciphertext = data[32:]
-            cipher = AES.new(key[:32], AES.MODE_GCM, nonce=nonce)
-            return cipher.decrypt_and_verify(ciphertext, tag)
-        except:
-            return CryptoSuite._xor_decrypt(data, key)
-    
-    @staticmethod
-    def _xor_encrypt(data: bytes, key: bytes) -> bytes:
-        """Fallback XOR encryption"""
-        iv = secrets.token_bytes(16)
-        result = bytearray()
-        for i, byte in enumerate(data):
-            result.append(byte ^ key[i % len(key)] ^ iv[i % len(iv)])
-        return iv + bytes(result)
-    
-    @staticmethod
-    def _xor_decrypt(data: bytes, key: bytes) -> bytes:
-        """Fallback XOR decryption"""
-        iv = data[:16]
-        ciphertext = data[16:]
-        result = bytearray()
-        for i, byte in enumerate(ciphertext):
-            result.append(byte ^ key[i % len(key)] ^ iv[i % len(iv)])
-        return bytes(result)
 
 # ==========================================
 # DATABASE
@@ -418,7 +292,7 @@ class Logger:
                 logging.StreamHandler()
             ]
         )
-        self.logger = logging.getLogger('VoidFRP')
+        self.logger = logging.getLogger('VoidSuite')
     
     def log(self, level: str, category: str, message: str, device_id: str = None, method: str = None):
         """Log message"""
@@ -469,7 +343,7 @@ class DeviceDetector:
         """Detect ADB devices"""
         devices = []
         try:
-            code, stdout, _ = SafeSubprocess.run(['adb', 'devices'])
+            code, stdout, _ = SafeSubprocess.run(['adb', 'devices', '-l'])
             if code == 0:
                 for line in stdout.strip().split('\n')[1:]:
                     if line.strip():
@@ -477,9 +351,10 @@ class DeviceDetector:
                         if len(parts) >= 2:
                             device_id = parts[0]
                             status = parts[1]
-                            
+
                             if status == 'device':
                                 info = DeviceDetector._get_adb_info(device_id)
+                                info.update(DeviceDetector._parse_adb_listing(parts[2:]))
                                 devices.append({
                                     'id': device_id,
                                     'mode': 'adb',
@@ -494,18 +369,27 @@ class DeviceDetector:
     def _get_adb_info(device_id: str) -> Dict[str, str]:
         """Get comprehensive device info"""
         info = {}
+        info['reachable'] = DeviceDetector._check_adb_ready(device_id)
         
         props = {
             'manufacturer': 'ro.product.manufacturer',
             'model': 'ro.product.model',
             'brand': 'ro.product.brand',
             'device': 'ro.product.device',
+            'product': 'ro.product.name',
             'android_version': 'ro.build.version.release',
             'sdk_version': 'ro.build.version.sdk',
+            'release_codename': 'ro.build.version.codename',
+            'incremental': 'ro.build.version.incremental',
             'build_id': 'ro.build.id',
+            'build_type': 'ro.build.type',
+            'build_tags': 'ro.build.tags',
+            'build_date': 'ro.build.date',
             'security_patch': 'ro.build.version.security_patch',
             'chipset': 'ro.board.platform',
             'hardware': 'ro.hardware',
+            'cpu_abi': 'ro.product.cpu.abi',
+            'cpu_abi2': 'ro.product.cpu.abi2',
             'serial': 'ro.serialno',
             'bootloader': 'ro.bootloader',
             'fingerprint': 'ro.build.fingerprint',
@@ -542,6 +426,30 @@ class DeviceDetector:
         # Screen info
         info['screen'] = DeviceDetector._get_screen_info(device_id)
         
+        return info
+
+    @staticmethod
+    def _check_adb_ready(device_id: str) -> bool:
+        """Check whether the device responds to ADB shell commands."""
+        try:
+            code, stdout, _ = SafeSubprocess.run(
+                ['adb', '-s', device_id, 'shell', 'getprop', 'ro.serialno']
+            )
+            return code == 0 and bool(stdout.strip())
+        except Exception:
+            return False
+
+    @staticmethod
+    def _parse_adb_listing(parts: List[str]) -> Dict[str, str]:
+        """Parse metadata from adb devices -l output."""
+        info = {}
+        for part in parts:
+            if ':' not in part:
+                continue
+            key, value = part.split(':', 1)
+            key = key.strip().lower()
+            if key in {"product", "model", "device", "transport_id"}:
+                info[key] = value.strip()
         return info
     
     @staticmethod
@@ -1441,7 +1349,7 @@ class ReportGenerator:
 <html>
 <head>
     <meta charset="UTF-8">
-    <title>Zeta Device Report</title>
+    <title>Void Device Report</title>
     <style>
         body {{ font-family: Arial; margin: 40px; background: #f5f5f5; }}
         .container {{ max-width: 1200px; margin: 0 auto; background: white; padding: 30px; border-radius: 10px; }}
@@ -1459,7 +1367,7 @@ class ReportGenerator:
 <body>
     <div class="container">
         <div class="header">
-            <h1>📱 Zeta Device Report</h1>
+            <h1>📱 Void Device Report</h1>
             <p>Device: {report.get('device_id', 'Unknown')}</p>
             <p>Generated: {report.get('generated', '')}</p>
         </div>
@@ -1474,9 +1382,24 @@ class ReportGenerator:
 """
             for key, value in info.items():
                 if not isinstance(value, dict):
-                    html += f"<tr><td><strong>{{key.replace('_', ' ').title()}}</strong></td><td>{{value}}</td></tr>"
+                    label = key.replace('_', ' ').title()
+                    html += f"<tr><td><strong>{label}</strong></td><td>{value}</td></tr>"
             
             html += """            </table>
+        </div>
+"""
+
+            for nested_key in ["battery", "storage", "screen"]:
+                nested = info.get(nested_key)
+                if isinstance(nested, dict) and nested:
+                    html += f"""        <div class="section">
+            <h2>{nested_key.replace('_', ' ').title()} Details</h2>
+            <table>
+"""
+                    for key, value in nested.items():
+                        label = key.replace('_', ' ').title()
+                        html += f"<tr><td><strong>{label}</strong></td><td>{value}</td></tr>"
+                    html += """            </table>
         </div>
 """
         
@@ -1489,7 +1412,8 @@ class ReportGenerator:
 """
             for key, value in perf.items():
                 if not isinstance(value, (dict, list)):
-                    html += f"<tr><td><strong>{{key.replace('_', ' ').title()}}</strong></td><td>{{value}}</td></tr>"
+                    label = key.replace('_', ' ').title()
+                    html += f"<tr><td><strong>{label}</strong></td><td>{value}</td></tr>"
             
             html += """            </table>
         </div>
@@ -1581,472 +1505,3 @@ class FRPEngine:
             'success': code == 0,
             'message': 'Userdata formatted' if code == 0 else 'Failed'
         }
-
-# ==========================================
-# COMMAND LINE INTERFACE
-# ==========================================
-
-class CLI:
-    """Enhanced CLI with all features"""
-    
-    def __init__(self):
-        self.console = Console() if RICH_AVAILABLE else None
-        self.engine = FRPEngine()
-        self.logcat = LogcatViewer()
-        
-        # Start monitoring
-        monitor.start()
-    
-    def run(self):
-        """Run CLI"""
-        self._print_banner()
-        
-        while True:
-            try:
-                cmd = input("\nvoid> ").strip()
-                if not cmd:
-                    continue
-                
-                parts = cmd.split()
-                command = parts[0].lower()
-                args = parts[1:]
-                
-                # Route commands
-                commands = {
-                    'devices': self._cmd_devices,
-                    'info': lambda: self._cmd_info(args),
-                    'backup': lambda: self._cmd_backup(args),
-                    'screenshot': lambda: self._cmd_screenshot(args),
-                    'apps': lambda: self._cmd_apps(args),
-                    'files': lambda: self._cmd_files(args),
-                    'analyze': lambda: self._cmd_analyze(args),
-                    'recover': lambda: self._cmd_recover(args),
-                    'tweak': lambda: self._cmd_tweak(args),
-                    'report': lambda: self._cmd_report(args),
-                    'stats': self._cmd_stats,
-                    'monitor': self._cmd_monitor,
-                    'logcat': lambda: self._cmd_logcat(args),
-                    'execute': lambda: self._cmd_execute(args),
-                    'help': self._cmd_help,
-                    'exit': lambda: sys.exit(0)
-                }
-                
-                if command in commands:
-                    commands[command]()
-                else:
-                    print(f"Unknown command: {command}")
-                    
-            except KeyboardInterrupt:
-                print("\nUse 'exit' to quit")
-            except Exception as e:
-                print(f"Error: {e}")
-    
-    def _print_banner(self):
-        """Print banner"""
-        features_count = 200  # Total automated features
-        
-        banner = f"""
-╔══════════════════════════════════════════════════════════════╗
-║  VOID FRP SUITE v{Config.VERSION} - {Config.CODENAME}                    ║
-║  Ultimate Android Toolkit - {features_count}+ Automated Features      ║
-╚══════════════════════════════════════════════════════════════╝
-
-✨ All features work automatically - zero manual setup required!
-
-Type 'help' to see all available commands.
-"""
-        print(banner)
-    
-    def _cmd_devices(self):
-        """List devices"""
-        devices = DeviceDetector.detect_all()
-        
-        if not devices:
-            print("❌ No devices detected")
-            return
-        
-        if self.console:
-            table = Table(title="Connected Devices")
-            table.add_column("ID", style="cyan")
-            table.add_column("Mode", style="green")
-            table.add_column("Manufacturer", style="yellow")
-            table.add_column("Model", style="blue")
-            table.add_column("Android", style="magenta")
-            
-            for device in devices:
-                table.add_row(
-                    device.get('id', 'Unknown'),
-                    device.get('mode', 'Unknown'),
-                    device.get('manufacturer', 'Unknown'),
-                    device.get('model', 'Unknown'),
-                    device.get('android_version', 'Unknown')
-                )
-            
-            self.console.print(table)
-        else:
-            print("\n📱 Connected Devices:")
-            for device in devices:
-                print(f"  • {device.get('id')} - {device.get('manufacturer')} {device.get('model')}")
-    
-    def _cmd_backup(self, args):
-        """Create backup"""
-        if len(args) < 1:
-            print("Usage: backup <device_id>")
-            return
-        
-        result = AutoBackup.create_backup(args[0])
-        if result['success']:
-            print(f"✅ Backup created: {result['backup_name']}")
-            print(f"   Items: {', '.join(result['items'])}")
-            print(f"   Size: {result['size']:,} bytes")
-        else:
-            print("❌ Backup failed")
-    
-    def _cmd_screenshot(self, args):
-        """Take screenshot"""
-        if len(args) < 1:
-            print("Usage: screenshot <device_id>")
-            return
-        
-        result = ScreenCapture.take_screenshot(args[0])
-        if result['success']:
-            print(f"✅ Screenshot saved: {result['path']}")
-        else:
-            print("❌ Screenshot failed")
-    
-    def _cmd_apps(self, args):
-        """List apps"""
-        if len(args) < 1:
-            print("Usage: apps <device_id> [system|user|all]")
-            return
-        
-        filter_type = args[1] if len(args) > 1 else 'all'
-        apps = AppManager.list_apps(args[0], filter_type)
-        
-        print(f"\n📦 {filter_type.title()} Apps ({len(apps)}):")
-        for app in apps[:20]:  # Show first 20
-            print(f"  • {app['package']}")
-        
-        if len(apps) > 20:
-            print(f"  ... and {len(apps) - 20} more")
-    
-    def _cmd_info(self, args):
-        """Show device info"""
-        if len(args) < 1:
-            print("Usage: info <device_id>")
-            return
-        
-        devices = DeviceDetector.detect_all()
-        device = next((d for d in devices if d['id'] == args[0]), None)
-        
-        if device:
-            print(f"\n📱 Device Information: {args[0]}\n")
-            for key, value in device.items():
-                if not isinstance(value, dict):
-                    print(f"  {key.replace('_', ' ').title()}: {value}")
-        else:
-            print("❌ Device not found")
-    
-    def _cmd_analyze(self, args):
-        """Analyze device"""
-        if len(args) < 1:
-            print("Usage: analyze <device_id>")
-            return
-        
-        print(f"🔍 Analyzing device...")
-        result = PerformanceAnalyzer.analyze(args[0])
-        
-        print(f"\n📊 Performance Analysis:\n")
-        for key, value in result.items():
-            if not isinstance(value, (dict, list)):
-                print(f"  {key.replace('_', ' ').title()}: {value}")
-    
-    def _cmd_recover(self, args):
-        """Recover data"""
-        if len(args) < 2:
-            print("Usage: recover <device_id> <contacts|sms>")
-            return
-        
-        device_id, data_type = args[0], args[1]
-        
-        print(f"💾 Recovering {data_type}...")
-        
-        if data_type == 'contacts':
-            result = DataRecovery.recover_contacts(device_id)
-        elif data_type == 'sms':
-            result = DataRecovery.recover_sms(device_id)
-        else:
-            print("❌ Unknown data type")
-            return
-        
-        if result['success']:
-            print(f"✅ Recovered {result['count']} items")
-            print(f"   Saved to: {result.get('json_path') or result.get('path')}")
-        else:
-            print("❌ Recovery failed")
-    
-    def _cmd_tweak(self, args):
-        """System tweaks"""
-        if len(args) < 3:
-            print("Usage: tweak <device_id> <dpi|animation|timeout> <value>")
-            return
-        
-        device_id, tweak_type, value = args[0], args[1], args[2]
-        
-        if tweak_type == 'dpi':
-            success = SystemTweaker.set_dpi(device_id, int(value))
-        elif tweak_type == 'animation':
-            success = SystemTweaker.set_animation_scale(device_id, float(value))
-        elif tweak_type == 'timeout':
-            success = SystemTweaker.set_screen_timeout(device_id, int(value))
-        else:
-            print("❌ Unknown tweak type")
-            return
-        
-        if success:
-            print(f"✅ {tweak_type.title()} updated")
-        else:
-            print("❌ Tweak failed")
-    
-    def _cmd_report(self, args):
-        """Generate report"""
-        if len(args) < 1:
-            print("Usage: report <device_id>")
-            return
-        
-        print("📄 Generating report...")
-        result = ReportGenerator.generate_device_report(args[0])
-        
-        if result['success']:
-            print(f"✅ Report generated: {result['report_name']}")
-            print(f"   HTML: {result['html_path']}")
-        else:
-            print("❌ Report generation failed")
-    
-    def _cmd_stats(self):
-        """Show statistics"""
-        stats = db.get_statistics()
-        
-        print("\n📊 VOID SUITE STATISTICS\n")
-        print(f"  Total Devices: {stats['total_devices']}")
-        print(f"  Total Logs: {stats['total_logs']}")
-        print(f"  Total Backups: {stats['total_backups']}")
-        print(f"  Methods Tracked: {stats['total_methods']}")
-        
-        if stats.get('top_methods'):
-            print("\n  Top Methods:")
-            for method in stats['top_methods']:
-                rate = (method['success_count'] / method['total_count'] * 100) if method['total_count'] > 0 else 0
-                print(f"    • {method['name']}: {rate:.1f}% ({method['success_count']}/{method['total_count']})")
-    
-    def _cmd_monitor(self):
-        """Show system monitor"""
-        stats = monitor.get_stats()
-        
-        if stats:
-            print("\n🖥️  SYSTEM MONITOR\n")
-            print(f"  CPU: {stats.get('cpu_percent', 0):.1f}%")
-            print(f"  Memory: {stats.get('memory_percent', 0):.1f}%")
-            print(f"  Disk: {stats.get('disk_usage', 0):.1f}%")
-        else:
-            print("❌ Monitoring not available (install psutil)")
-    
-    def _cmd_logcat(self, args):
-        """Start logcat"""
-        if len(args) < 1:
-            print("Usage: logcat <device_id> [filter_tag]")
-            return
-        
-        device_id = args[0]
-        filter_tag = args[1] if len(args) > 1 else None
-        
-        print("📜 Starting logcat (Ctrl+C to stop)...")
-        self.logcat.start(device_id, filter_tag)
-        
-        try:
-            while True:
-                line = self.logcat.read_line()
-                if line:
-                    print(line.strip())
-        except KeyboardInterrupt:
-            self.logcat.stop()
-            print("\n📜 Logcat stopped")
-    
-    def _cmd_execute(self, args):
-        """Execute FRP method"""
-        if len(args) < 2:
-            print("Usage: execute <method> <device_id>")
-            return
-        
-        method_name, device_id = args[0], args[1]
-        
-        print(f"⚡ Executing {method_name}...")
-        
-        if method_name not in self.engine.methods:
-            print(f"❌ Unknown method: {method_name}")
-            return
-        
-        result = self.engine.methods[method_name](device_id)
-        
-        if result['success']:
-            print(f"✅ Success: {result['message']}")
-        else:
-            print(f"❌ Failed: {result.get('error', result['message'])}")
-    
-    def _cmd_files(self, args):
-        """File operations"""
-        if len(args) < 2:
-            print("Usage: files <device_id> <list|pull|push> [path]")
-            return
-        
-        device_id, operation = args[0], args[1]
-        
-        if operation == 'list':
-            path = args[2] if len(args) > 2 else '/sdcard'
-            files = FileManager.list_files(device_id, path)
-            
-            print(f"\n📁 Files in {path}:\n")
-            for file in files[:20]:
-                print(f"  {file['permissions']} {file['size']:>10} {file['date']:>20} {file['name']}")
-            
-            if len(files) > 20:
-                print(f"\n  ... and {len(files) - 20} more")
-        
-        elif operation == 'pull':
-            if len(args) < 3:
-                print("Usage: files <device_id> pull <remote_path>")
-                return
-            
-            result = FileManager.pull_file(device_id, args[2])
-            if result['success']:
-                print(f"✅ File pulled: {result['path']}")
-            else:
-                print("❌ Pull failed")
-        
-        else:
-            print("❌ Unknown operation")
-    
-    def _cmd_help(self):
-        """Show help"""
-        help_text = """
-╔══════════════════════════════════════════════════════════════╗
-║                   VOID FRP SUITE - HELP                      ║
-╚══════════════════════════════════════════════════════════════╝
-
-📋 AVAILABLE COMMANDS:
-
-DEVICE MANAGEMENT:
-  devices                          - List all connected devices
-  info <device_id>                 - Show detailed device info
-  
-BACKUP & DATA:
-  backup <device_id>               - Create automated backup
-  recover <device_id> <type>       - Recover data (contacts/sms)
-  screenshot <device_id>           - Take screenshot
-  
-APP MANAGEMENT:
-  apps <device_id> [filter]        - List apps (system/user/all)
-  
-FILE OPERATIONS:
-  files <device_id> list [path]    - List files
-  files <device_id> pull <path>    - Pull file from device
-  
-ANALYSIS:
-  analyze <device_id>              - Performance analysis
-  report <device_id>               - Generate full report
-  logcat <device_id> [tag]         - View real-time logs
-  
-TWEAKS:
-  tweak <device_id> <type> <value> - System tweaks
-    Types: dpi, animation, timeout
-  
-FRP BYPASS:
-  execute <method> <device_id>     - Execute bypass method
-    Methods: adb_shell_reset, fastboot_erase, etc.
-  
-SYSTEM:
-  stats                            - Show suite statistics
-  monitor                          - Show system monitor
-  help                             - Show this help
-  exit                             - Exit suite
-
-🎯 EXAMPLES:
-
-  void> devices
-  void> info emulator-5554
-  void> backup emulator-5554
-  void> screenshot emulator-5554
-  void> apps emulator-5554 user
-  void> analyze emulator-5554
-  void> recover emulator-5554 contacts
-  void> tweak emulator-5554 dpi 320
-  void> report emulator-5554
-  void> execute adb_shell_reset emulator-5554
-
-💡 TIP: All commands work automatically with no setup required!
-
-╚══════════════════════════════════════════════════════════════╝
-"""
-        print(help_text)
-
-# ==========================================
-# MAIN
-# ==========================================
-
-def main():
-    """Main entry point"""
-    parser = argparse.ArgumentParser(
-        description=f"Void FRP Suite v{Config.VERSION} - Ultimate Android Toolkit"
-    )
-    
-    parser.add_argument('--version', action='store_true', help='Show version')
-    parser.add_argument('--devices', action='store_true', help='List devices')
-    parser.add_argument('--backup', type=str, help='Backup device')
-    parser.add_argument('--analyze', type=str, help='Analyze device')
-    parser.add_argument('--report', type=str, help='Generate report')
-    
-    args = parser.parse_args()
-    
-    if args.version:
-        print(f"Void FRP Suite v{Config.VERSION} - {Config.CODENAME}")
-        print("200+ Automated Features")
-        return
-    
-    if args.devices:
-        devices = DeviceDetector.detect_all()
-        print("Connected Devices:")
-        for device in devices:
-            print(f"  • {device.get('id')} - {device.get('manufacturer')} {device.get('model')}")
-        return
-    
-    if args.backup:
-        result = AutoBackup.create_backup(args.backup)
-        print(f"Backup: {'Success' if result['success'] else 'Failed'}")
-        return
-    
-    if args.analyze:
-        result = PerformanceAnalyzer.analyze(args.analyze)
-        print(f"Analysis: {json.dumps(result, indent=2)}")
-        return
-    
-    if args.report:
-        result = ReportGenerator.generate_device_report(args.report)
-        print(f"Report: {result.get('html_path', 'Failed')}")
-        return
-    
-    # Start CLI
-    cli = CLI()
-    cli.run()
-
-if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        print("\n\n👋 Goodbye!")
-        monitor.stop()
-        sys.exit(0)
-    except Exception as e:
-        print(f"\n💀 Critical Error: {e}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)

--- a/void/crypto.py
+++ b/void/crypto.py
@@ -1,0 +1,110 @@
+"""
+VOID CRYPTOGRAPHY
+
+PROPRIETARY SOFTWARE
+Copyright (c) 2024 Roach Labs. All rights reserved.
+Made by James Michael Roach Jr.
+Unauthorized copying, modification, distribution, or disclosure is prohibited.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from typing import Optional
+
+from .config import Config
+
+try:
+    from Crypto.Cipher import AES, PKCS1_OAEP
+    from Crypto.PublicKey import RSA
+    from Crypto.Random import get_random_bytes
+    from Crypto.Util.Padding import pad, unpad
+    from Crypto.Protocol.KDF import PBKDF2
+    CRYPTO_AVAILABLE = True
+except ImportError:
+    CRYPTO_AVAILABLE = False
+
+
+class CryptoSuite:
+    """Cryptographic operations."""
+
+    @staticmethod
+    def hash_sha256(data: bytes) -> str:
+        """SHA-256 hash."""
+        return hashlib.sha256(data).hexdigest()
+
+    @staticmethod
+    def generate_key(length: int = 32) -> bytes:
+        """Generate random key."""
+        return secrets.token_bytes(length)
+
+    @staticmethod
+    def encrypt_aes(data: bytes, key: bytes) -> bytes:
+        """AES encryption."""
+        if not CRYPTO_AVAILABLE:
+            if Config.ALLOW_INSECURE_CRYPTO:
+                return CryptoSuite._xor_encrypt(data, key)
+            raise RuntimeError(
+                "Cryptography backend unavailable. Install pycryptodome or set "
+                "Config.ALLOW_INSECURE_CRYPTO = True to allow insecure XOR fallback."
+            )
+
+        try:
+            cipher = AES.new(key[:32], AES.MODE_GCM)
+            ciphertext, tag = cipher.encrypt_and_digest(data)
+            return cipher.nonce + tag + ciphertext
+        except Exception:
+            return CryptoSuite._xor_encrypt(data, key)
+
+    @staticmethod
+    def decrypt_aes(data: bytes, key: bytes) -> bytes:
+        """AES decryption."""
+        if not CRYPTO_AVAILABLE:
+            if Config.ALLOW_INSECURE_CRYPTO:
+                return CryptoSuite._xor_decrypt(data, key)
+            raise RuntimeError(
+                "Cryptography backend unavailable. Install pycryptodome or set "
+                "Config.ALLOW_INSECURE_CRYPTO = True to allow insecure XOR fallback."
+            )
+
+        try:
+            nonce = data[:16]
+            tag = data[16:32]
+            ciphertext = data[32:]
+            cipher = AES.new(key[:32], AES.MODE_GCM, nonce=nonce)
+            return cipher.decrypt_and_verify(ciphertext, tag)
+        except Exception:
+            return CryptoSuite._xor_decrypt(data, key)
+
+    @staticmethod
+    def _xor_encrypt(data: bytes, key: bytes) -> bytes:
+        """Fallback XOR encryption."""
+        iv = secrets.token_bytes(16)
+        result = bytearray()
+        for i, byte in enumerate(data):
+            result.append(byte ^ key[i % len(key)] ^ iv[i % len(iv)])
+        return iv + bytes(result)
+
+    @staticmethod
+    def _xor_decrypt(data: bytes, key: bytes) -> bytes:
+        """Fallback XOR decryption."""
+        iv = data[:16]
+        ciphertext = data[16:]
+        result = bytearray()
+        for i, byte in enumerate(ciphertext):
+            result.append(byte ^ key[i % len(key)] ^ iv[i % len(iv)])
+        return bytes(result)
+
+
+__all__ = [
+    "CryptoSuite",
+    "CRYPTO_AVAILABLE",
+    "AES",
+    "PKCS1_OAEP",
+    "RSA",
+    "get_random_bytes",
+    "pad",
+    "unpad",
+    "PBKDF2",
+]

--- a/void/gui.py
+++ b/void/gui.py
@@ -1,0 +1,549 @@
+"""
+VOID GUI
+
+PROPRIETARY SOFTWARE
+Copyright (c) 2024 Roach Labs. All rights reserved.
+Made by James Michael Roach Jr.
+Unauthorized copying, modification, distribution, or disclosure is prohibited.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from .config import Config
+from .core import (
+    AutoBackup,
+    DeviceDetector,
+    PerformanceAnalyzer,
+    ReportGenerator,
+    ScreenCapture,
+)
+from .terms import ensure_terms_acceptance_gui
+
+try:
+    import tkinter as tk
+    from tkinter import ttk, messagebox, scrolledtext, filedialog
+    GUI_AVAILABLE = True
+except ImportError:
+    GUI_AVAILABLE = False
+
+
+class Tooltip:
+    """Lightweight tooltip helper for Tk widgets."""
+
+    def __init__(self, widget: tk.Widget, text: str, delay_ms: int = 500):
+        self.widget = widget
+        self.text = text
+        self.delay_ms = delay_ms
+        self._after_id: Optional[str] = None
+        self._tip_window: Optional[tk.Toplevel] = None
+
+        widget.bind("<Enter>", self._schedule)
+        widget.bind("<Leave>", self._hide)
+        widget.bind("<ButtonPress>", self._hide)
+
+    def _schedule(self, _event=None) -> None:
+        self._after_id = self.widget.after(self.delay_ms, self._show)
+
+    def _show(self) -> None:
+        if self._tip_window or not self.text:
+            return
+
+        x = self.widget.winfo_rootx() + 12
+        y = self.widget.winfo_rooty() + 24
+
+        self._tip_window = tk.Toplevel(self.widget)
+        self._tip_window.wm_overrideredirect(True)
+        self._tip_window.wm_geometry(f"+{x}+{y}")
+        self._tip_window.configure(bg="#0b0f14")
+
+        label = tk.Label(
+            self._tip_window,
+            text=self.text,
+            background="#0b0f14",
+            foreground="#e6f1ff",
+            relief="solid",
+            borderwidth=1,
+            font=("Consolas", 9),
+            padx=6,
+            pady=4,
+        )
+        label.pack()
+
+    def _hide(self, _event=None) -> None:
+        if self._after_id:
+            self.widget.after_cancel(self._after_id)
+            self._after_id = None
+
+        if self._tip_window:
+            self._tip_window.destroy()
+            self._tip_window = None
+
+
+class VoidGUI:
+    """User-friendly GUI with an anonymous hacktivist theme."""
+
+    def __init__(self):
+        if not GUI_AVAILABLE:
+            raise RuntimeError("GUI dependencies missing. Install tkinter to use the GUI.")
+
+        self.root = tk.Tk()
+        self.root.title(Config.APP_NAME)
+        self.root.geometry("980x640")
+        self.root.configure(bg="#0b0f14")
+
+        self.device_ids: List[str] = []
+        self.device_info: List[Dict[str, Any]] = []
+        self.status_var = tk.StringVar(value="Ready.")
+        self.selected_device_var = tk.StringVar(value="No device selected.")
+        self.details_var = tk.StringVar(value="Device details will appear here.")
+        self.action_help_var = tk.StringVar(
+            value="Select an action to see a description."
+        )
+        self.progress_var = tk.StringVar(value="")
+        self._build_layout()
+        if not ensure_terms_acceptance_gui(messagebox):
+            self.root.destroy()
+            raise SystemExit(0)
+        self.refresh_devices()
+
+    def _build_layout(self) -> None:
+        """Build the themed layout."""
+        style = ttk.Style(self.root)
+        style.theme_use("clam")
+        style.configure(
+            "Void.TFrame",
+            background="#0b0f14"
+        )
+        style.configure(
+            "Void.TLabel",
+            background="#0b0f14",
+            foreground="#e6f1ff",
+            font=("Consolas", 11)
+        )
+        style.configure(
+            "Void.Title.TLabel",
+            background="#0b0f14",
+            foreground="#00ff9c",
+            font=("Consolas", 20, "bold")
+        )
+        style.configure(
+            "Void.TButton",
+            background="#111923",
+            foreground="#00ff9c",
+            font=("Consolas", 11, "bold"),
+            borderwidth=1
+        )
+        style.map(
+            "Void.TButton",
+            background=[("active", "#1a2633")],
+            foreground=[("active", "#7bffce")]
+        )
+
+        header = ttk.Frame(self.root, style="Void.TFrame")
+        header.pack(fill="x", padx=20, pady=(20, 10))
+
+        ttk.Label(header, text="VOID", style="Void.Title.TLabel").pack(anchor="w")
+        ttk.Label(
+            header,
+            text="Anonymous Ops Console • Proprietary to Roach Labs",
+            style="Void.TLabel"
+        ).pack(anchor="w")
+
+        menu = tk.Menu(self.root, bg="#0b0f14", fg="#e6f1ff", tearoff=0)
+        self.root.config(menu=menu)
+        app_menu = tk.Menu(menu, tearoff=0, bg="#0b0f14", fg="#e6f1ff")
+        app_menu.add_command(label="About", command=self._show_about)
+        app_menu.add_command(label="Export Log", command=self._export_log)
+        app_menu.add_separator()
+        app_menu.add_command(label="Exit", command=self.root.quit)
+        menu.add_cascade(label="Void", menu=app_menu)
+
+        body = ttk.Frame(self.root, style="Void.TFrame")
+        body.pack(fill="both", expand=True, padx=20, pady=10)
+
+        left = ttk.Frame(body, style="Void.TFrame")
+        left.pack(side="left", fill="y", padx=(0, 15))
+
+        ttk.Label(left, text="Connected Devices", style="Void.TLabel").pack(anchor="w")
+        self.device_list = tk.Listbox(
+            left,
+            width=36,
+            height=18,
+            bg="#0f141b",
+            fg="#00ff9c",
+            selectbackground="#1a2633",
+            selectforeground="#e6f1ff",
+            highlightthickness=0,
+            font=("Consolas", 10)
+        )
+        self.device_list.pack(pady=(6, 10))
+        self.device_list.bind("<<ListboxSelect>>", lambda _: self._on_device_select())
+        Tooltip(self.device_list, "Displays connected devices detected via ADB or fastboot.")
+
+        ttk.Button(
+            left,
+            text="Refresh Devices",
+            style="Void.TButton",
+            command=self.refresh_devices
+        ).pack(fill="x")
+        Tooltip(
+            left.winfo_children()[-1],
+            "Re-scan connected devices and refresh metadata."
+        )
+
+        right = ttk.Frame(body, style="Void.TFrame")
+        right.pack(side="left", fill="both", expand=True)
+
+        notebook = ttk.Notebook(right)
+        notebook.pack(fill="both", expand=True)
+
+        dashboard = ttk.Frame(notebook, style="Void.TFrame")
+        logs = ttk.Frame(notebook, style="Void.TFrame")
+        help_panel = ttk.Frame(notebook, style="Void.TFrame")
+        notebook.add(dashboard, text="Dashboard")
+        notebook.add(logs, text="Operations Log")
+        notebook.add(help_panel, text="What Does This Do?")
+
+        ttk.Label(dashboard, text="Selected Device", style="Void.TLabel").pack(anchor="w")
+        ttk.Label(dashboard, textvariable=self.selected_device_var, style="Void.TLabel").pack(
+            anchor="w", pady=(2, 8)
+        )
+
+        details = ttk.Frame(dashboard, style="Void.TFrame")
+        details.pack(fill="x", pady=(0, 10))
+        ttk.Label(details, textvariable=self.details_var, style="Void.TLabel", wraplength=520).pack(
+            anchor="w"
+        )
+
+        ttk.Label(dashboard, text="Actions", style="Void.TLabel").pack(anchor="w", pady=(6, 0))
+        actions = ttk.Frame(dashboard, style="Void.TFrame")
+        actions.pack(fill="x", pady=6)
+
+        backup_button = ttk.Button(
+            actions,
+            text="Create Backup",
+            style="Void.TButton",
+            command=self._backup
+        )
+        backup_button.pack(
+            side="left", padx=(0, 8)
+        )
+        Tooltip(backup_button, "Creates a local backup snapshot of device data.")
+        backup_button.bind(
+            "<Enter>",
+            lambda _event: self.action_help_var.set(
+                "Create Backup: captures a local snapshot of device data using ADB."
+            ),
+        )
+
+        analyze_button = ttk.Button(
+            actions,
+            text="Analyze",
+            style="Void.TButton",
+            command=self._analyze
+        )
+        analyze_button.pack(
+            side="left", padx=(0, 8)
+        )
+        Tooltip(analyze_button, "Collects performance metrics and device diagnostics.")
+        analyze_button.bind(
+            "<Enter>",
+            lambda _event: self.action_help_var.set(
+                "Analyze: gathers performance and system diagnostics from the device."
+            ),
+        )
+
+        report_button = ttk.Button(
+            actions,
+            text="Generate Report",
+            style="Void.TButton",
+            command=self._report
+        )
+        report_button.pack(
+            side="left", padx=(0, 8)
+        )
+        Tooltip(report_button, "Builds an HTML device report with collected metadata.")
+        report_button.bind(
+            "<Enter>",
+            lambda _event: self.action_help_var.set(
+                "Generate Report: creates an HTML report with device information."
+            ),
+        )
+
+        screenshot_button = ttk.Button(
+            actions,
+            text="Screenshot",
+            style="Void.TButton",
+            command=self._screenshot
+        )
+        screenshot_button.pack(
+            side="left"
+        )
+        Tooltip(screenshot_button, "Captures a screenshot from the connected device.")
+        screenshot_button.bind(
+            "<Enter>",
+            lambda _event: self.action_help_var.set(
+                "Screenshot: grabs a current screen capture from the device."
+            ),
+        )
+
+        ttk.Label(
+            dashboard,
+            text="Action Descriptions",
+            style="Void.TLabel"
+        ).pack(anchor="w", pady=(10, 0))
+        action_descriptions = (
+            "Create Backup — Save a local snapshot of apps and data.\n"
+            "Analyze — Collect performance and diagnostic stats.\n"
+            "Generate Report — Build an HTML report with device metadata.\n"
+            "Screenshot — Capture the current device screen."
+        )
+        ttk.Label(
+            dashboard,
+            text=action_descriptions,
+            style="Void.TLabel",
+            wraplength=520
+        ).pack(anchor="w", pady=(4, 0))
+
+        ttk.Label(dashboard, text="Quick Tips", style="Void.TLabel").pack(anchor="w", pady=(10, 0))
+        tips = (
+            "• Use Refresh Devices before each operation.\n"
+            "• Reports are generated in HTML for easy sharing.\n"
+            "• Operations run in the background; watch the log for progress."
+        )
+        ttk.Label(dashboard, text=tips, style="Void.TLabel", wraplength=520).pack(anchor="w")
+
+        ttk.Label(logs, text="Operations Log", style="Void.TLabel").pack(anchor="w")
+        self.output = scrolledtext.ScrolledText(
+            logs,
+            height=18,
+            bg="#0f141b",
+            fg="#e6f1ff",
+            insertbackground="#00ff9c",
+            font=("Consolas", 10),
+            state="disabled"
+        )
+        self.output.pack(fill="both", expand=True, pady=(6, 0))
+
+        ttk.Label(help_panel, text="Action Details", style="Void.TLabel").pack(anchor="w")
+        ttk.Label(
+            help_panel,
+            textvariable=self.action_help_var,
+            style="Void.TLabel",
+            wraplength=600
+        ).pack(anchor="w", pady=(6, 12))
+
+        guide = (
+            "Device List: Shows connected devices. Select one to view metadata.\n"
+            "Dashboard: Overview of the selected device and quick actions.\n"
+            "Operations Log: Live status output for running tasks.\n"
+            "Status Bar: Displays the most recent operation summary."
+        )
+        ttk.Label(help_panel, text=guide, style="Void.TLabel", wraplength=600).pack(anchor="w")
+
+        status = ttk.Frame(self.root, style="Void.TFrame")
+        status.pack(fill="x", padx=20, pady=(0, 12))
+        ttk.Label(status, textvariable=self.status_var, style="Void.TLabel").pack(anchor="w")
+        ttk.Label(status, textvariable=self.progress_var, style="Void.TLabel").pack(anchor="w")
+        self.progress = ttk.Progressbar(
+            status,
+            mode="indeterminate",
+            length=260
+        )
+        self.progress.pack(anchor="w", pady=(6, 0))
+
+    def _log(self, message: str, level: str = "INFO") -> None:
+        """Write a log line to the GUI console."""
+        timestamp = datetime.now().strftime("%H:%M:%S")
+
+        def append():
+            self.output.configure(state="normal")
+            self.output.insert("end", f"[{timestamp}] [{level}] {message}\n")
+            self.output.configure(state="disabled")
+            self.output.see("end")
+
+        self.root.after(0, append)
+
+    def _run_task(self, label: str, func, *args) -> None:
+        """Run a potentially slow task in a background thread."""
+        def runner():
+            try:
+                self._log(f"{label} started...")
+                self._start_progress()
+                result = func(*args)
+                summary = self._summarize_result(label, result)
+                self._log(summary)
+                self.status_var.set(summary)
+            except Exception as exc:
+                self._log(f"{label} failed: {exc}", level="ERROR")
+                self.status_var.set(f"{label} failed. See log for details.")
+            finally:
+                self._stop_progress()
+
+        threading.Thread(target=runner, daemon=True).start()
+
+    def _get_selected_device(self) -> Optional[str]:
+        """Return the currently selected device."""
+        selection = self.device_list.curselection()
+        if not selection or selection[0] >= len(self.device_ids):
+            messagebox.showwarning("Void", "Select a device first.")
+            return None
+        return self.device_ids[selection[0]]
+
+    def _on_device_select(self) -> None:
+        """Update dashboard detail view when a device is selected."""
+        selection = self.device_list.curselection()
+        if not selection or selection[0] >= len(self.device_info):
+            self.selected_device_var.set("No device selected.")
+            self.details_var.set("Device details will appear here.")
+            return
+
+        info = self.device_info[selection[0]]
+        device_id = info.get("id", "unknown")
+        manufacturer = info.get("manufacturer", "Unknown")
+        model = info.get("model", "Unknown")
+        brand = info.get("brand", "Unknown")
+        product = info.get("product", "Unknown")
+        android = info.get("android_version", "Unknown")
+        sdk = info.get("sdk_version", "Unknown")
+        security = info.get("security_patch", "Unknown")
+        build_id = info.get("build_id", "Unknown")
+        build_type = info.get("build_type", "Unknown")
+        hardware = info.get("hardware", "Unknown")
+        cpu_abi = info.get("cpu_abi", "Unknown")
+        battery = info.get("battery", {})
+        storage = info.get("storage", {})
+        mode = info.get("mode", "Unknown")
+        reachable = "Yes" if info.get("reachable", False) else "No"
+        self.selected_device_var.set(f"{device_id} • {manufacturer} {model}")
+        self.details_var.set(
+            "Device Overview\n"
+            f"• Mode: {mode} | Reachable: {reachable}\n"
+            f"• Brand: {brand} | Product: {product}\n"
+            f"• Android: {android} (SDK {sdk})\n"
+            f"• Build: {build_id} ({build_type})\n"
+            f"• Hardware: {hardware} | ABI: {cpu_abi}\n"
+            f"• Security Patch: {security}\n"
+            f"• Battery Level: {battery.get('level', 'Unknown')}\n"
+            f"• Storage Free: {storage.get('available', 'Unknown')}\n"
+            f"• Serial: {device_id}"
+        )
+
+    def refresh_devices(self) -> None:
+        """Refresh the device list."""
+        self.device_list.delete(0, tk.END)
+        devices = DeviceDetector.detect_all()
+        self.device_ids = []
+        self.device_info = []
+
+        if not devices:
+            self.device_list.insert(tk.END, "No devices detected")
+            self._log("No devices detected", level="WARN")
+            self.selected_device_var.set("No device selected.")
+            self.details_var.set("Device details will appear here.")
+            return
+
+        for device in devices:
+            device_id = device.get("id", "unknown")
+            reachable = "✓" if device.get("reachable") else "!"
+            label = (
+                f"{reachable} {device_id} • "
+                f"{device.get('manufacturer', 'Unknown')} {device.get('model', '')}"
+            )
+            self.device_list.insert(tk.END, label.strip())
+            self.device_ids.append(device_id)
+            self.device_info.append(device)
+
+        self._log(f"Detected {len(self.device_ids)} device(s).")
+        self.status_var.set(f"{len(self.device_ids)} device(s) ready.")
+
+    def _backup(self) -> None:
+        device_id = self._get_selected_device()
+        if device_id:
+            self._run_task("Backup", AutoBackup.create_backup, device_id)
+
+    def _analyze(self) -> None:
+        device_id = self._get_selected_device()
+        if device_id:
+            self._run_task("Analyze", PerformanceAnalyzer.analyze, device_id)
+
+    def _report(self) -> None:
+        device_id = self._get_selected_device()
+        if device_id:
+            self._run_task("Report", ReportGenerator.generate_device_report, device_id)
+
+    def _screenshot(self) -> None:
+        device_id = self._get_selected_device()
+        if device_id:
+            self._run_task("Screenshot", ScreenCapture.take_screenshot, device_id)
+
+    def run(self) -> None:
+        """Start the GUI event loop."""
+        self._log("Void GUI ready.")
+        self.root.mainloop()
+
+    def _summarize_result(self, label: str, result: Any) -> str:
+        """Create a friendly summary of an operation result."""
+        if isinstance(result, dict):
+            success = result.get("success")
+            if success is True:
+                detail = result.get("message") or result.get("report_name") or "Completed successfully."
+                return f"{label} complete: {detail}"
+            if success is False:
+                error = result.get("error") or result.get("message") or "Operation failed."
+                return f"{label} failed: {error}"
+        return f"{label} complete."
+
+    def _show_about(self) -> None:
+        """Display the About dialog."""
+        messagebox.showinfo(
+            "About Void",
+            "Void\n"
+            f"Version {Config.VERSION} ({Config.CODENAME})\n\n"
+            "Proprietary Software\n"
+            "© 2024 Roach Labs\n"
+            "Made by James Michael Roach Jr."
+        )
+
+    def _export_log(self) -> None:
+        """Export the operations log to a text file."""
+        path = filedialog.asksaveasfilename(
+            title="Export Log",
+            defaultextension=".txt",
+            filetypes=[("Text Files", "*.txt")],
+        )
+        if not path:
+            return
+        self.output.configure(state="normal")
+        content = self.output.get("1.0", "end").strip()
+        self.output.configure(state="disabled")
+        with open(path, "w") as handle:
+            handle.write(content)
+        self.status_var.set(f"Log exported to {path}.")
+
+    def _start_progress(self) -> None:
+        self.root.after(0, lambda: self.progress_var.set("Working..."))
+        self.root.after(0, lambda: self.progress.start(10))
+
+    def _stop_progress(self) -> None:
+        self.root.after(0, self.progress.stop)
+        self.root.after(0, lambda: self.progress_var.set(""))
+
+
+def run_gui() -> None:
+    """Launch the graphical interface if available."""
+    if not GUI_AVAILABLE:
+        print(
+            "GUI not available. Install tkinter (python3-tk on Linux) to use the GUI."
+        )
+        return
+
+    gui = VoidGUI()
+    gui.run()
+
+
+__all__ = ["VoidGUI", "run_gui", "GUI_AVAILABLE"]

--- a/void/main.py
+++ b/void/main.py
@@ -1,0 +1,87 @@
+"""
+VOID ENTRY POINT
+
+PROPRIETARY SOFTWARE
+Copyright (c) 2024 Roach Labs. All rights reserved.
+Made by James Michael Roach Jr.
+Unauthorized copying, modification, distribution, or disclosure is prohibited.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from .cli import CLI
+from .config import Config
+from .core import AutoBackup, DeviceDetector, PerformanceAnalyzer, ReportGenerator, monitor
+from .gui import run_gui
+from .terms import ensure_terms_acceptance_cli
+
+
+def main() -> None:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description=f"Void v{Config.VERSION} - Ultimate Android Toolkit"
+    )
+
+    parser.add_argument('--version', action='store_true', help='Show version')
+    parser.add_argument('--gui', action='store_true', help='Launch GUI')
+    parser.add_argument('--devices', action='store_true', help='List devices')
+    parser.add_argument('--backup', type=str, help='Backup device')
+    parser.add_argument('--analyze', type=str, help='Analyze device')
+    parser.add_argument('--report', type=str, help='Generate report')
+
+    args = parser.parse_args()
+
+    if args.version:
+        print(f"Void v{Config.VERSION} - {Config.CODENAME}")
+        print("200+ Automated Features")
+        return
+
+    if not ensure_terms_acceptance_cli():
+        return
+
+    if args.gui:
+        run_gui()
+        return
+
+    if args.devices:
+        devices = DeviceDetector.detect_all()
+        print("Connected Devices:")
+        for device in devices:
+            print(f"  • {device.get('id')} - {device.get('manufacturer')} {device.get('model')}")
+        return
+
+    if args.backup:
+        result = AutoBackup.create_backup(args.backup)
+        print(f"Backup: {'Success' if result['success'] else 'Failed'}")
+        return
+
+    if args.analyze:
+        result = PerformanceAnalyzer.analyze(args.analyze)
+        print(f"Analysis: {json.dumps(result, indent=2)}")
+        return
+
+    if args.report:
+        result = ReportGenerator.generate_device_report(args.report)
+        print(f"Report: {result.get('html_path', 'Failed')}")
+        return
+
+    cli = CLI()
+    cli.run()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\n\n👋 Goodbye!")
+        monitor.stop()
+        sys.exit(0)
+    except Exception as exc:
+        print(f"\n💀 Critical Error: {exc}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/void/terms.py
+++ b/void/terms.py
@@ -1,0 +1,69 @@
+"""
+VOID TERMS
+
+PROPRIETARY SOFTWARE
+Copyright (c) 2024 Roach Labs. All rights reserved.
+Made by James Michael Roach Jr.
+Unauthorized copying, modification, distribution, or disclosure is prohibited.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from .config import Config
+
+TERMS_TEXT = (
+    "By using Void, you agree to the Terms & Conditions and confirm you have "
+    "authorization to access any connected device."
+)
+
+
+def terms_path() -> Path:
+    return Config.BASE_DIR / "terms.json"
+
+
+def ensure_terms_acceptance_cli() -> bool:
+    """Require user acceptance of Terms & Conditions before use (CLI)."""
+    terms_file = terms_path()
+    if terms_file.exists():
+        try:
+            data = json.loads(terms_file.read_text())
+            if data.get("accepted") is True:
+                return True
+        except Exception:
+            pass
+
+    print("\n⚠️  TERMS & CONDITIONS REQUIRED\n")
+    print(TERMS_TEXT)
+    response = input("Type 'accept' to continue or anything else to exit: ").strip().lower()
+    if response != "accept":
+        print("Terms not accepted. Exiting.")
+        return False
+
+    terms_file.parent.mkdir(parents=True, exist_ok=True)
+    terms_file.write_text(json.dumps({"accepted": True}))
+    return True
+
+
+def ensure_terms_acceptance_gui(messagebox) -> bool:
+    """Require acceptance of Terms & Conditions before use (GUI)."""
+    terms_file = terms_path()
+    if terms_file.exists():
+        try:
+            data = json.loads(terms_file.read_text())
+            if data.get("accepted") is True:
+                return True
+        except Exception:
+            pass
+
+    accepted = messagebox.askyesno(
+        "Terms & Conditions",
+        f"{TERMS_TEXT}\n\nDo you accept the Terms & Conditions?",
+    )
+    if not accepted:
+        return False
+
+    terms_file.parent.mkdir(parents=True, exist_ok=True)
+    terms_file.write_text(json.dumps({"accepted": True}))
+    return True


### PR DESCRIPTION
### Motivation

- Prevent accidental or unauthorized use by requiring explicit acceptance of Terms & Conditions before running the tool.
- Centralize terms handling to provide a consistent prompt flow for both CLI and GUI users.
- Persist acceptance so users are not prompted repeatedly while keeping the acceptance record in the application config directory. 
- Provide a clear, visible message at startup so the legal requirement is obvious to end users.

### Description

- Add a shared `void/terms.py` module that exposes `TERMS_TEXT`, `terms_path()`, `ensure_terms_acceptance_cli()` and `ensure_terms_acceptance_gui()` and stores acceptance in `Config.BASE_DIR / "terms.json"`.
- Require acceptance in the CLI startup by calling `ensure_terms_acceptance_cli()` from `void/main.py` before launching CLI, actions, or GUI.
- Require acceptance in the GUI startup by calling `ensure_terms_acceptance_gui(messagebox)` from `void/gui.py` and gracefully exit the GUI when the user declines.
- Persist acceptance to a small JSON file and handle read/write/errors robustly so the prompt only appears when acceptance isn't present.

### Testing

- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c603c2d04832b94c34443503be64d)