### PR TITLE
Add interactive menu, diagnostics utilities, DB reporting, and bump to 6.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "void-suite"
-version = "6.0.0"
+version = "6.0.1"
 description = "Void Suite - Android toolkit"
 requires-python = ">=3.9"
 

--- a/void/config.py
+++ b/void/config.py
@@ -13,7 +13,7 @@ from pathlib import Path
 class Config:
     """Configuration constants."""
 
-    VERSION = "6.0.0"
+    VERSION = "6.0.1"
     CODENAME = "AUTOMATION"
     APP_NAME = "Void"
 


### PR DESCRIPTION
### Motivation

- Provide a navigable, discoverable interactive CLI to speed common flows and reduce command memorization.  
- Surface diagnostics, export, and housekeeping utilities from the CLI to make maintenance and troubleshooting easier.  
- Improve observability by tracking report generation and adding recent/top queries to the database API.  
- Harden CLI input handling by guarding against overly long input and remembering the last-used device for faster workflows.

### Description

- Implemented a full interactive menu (`_cmd_menu`, `_run_menu`, `_render_menu`, `_menu_*` subtrees) with numeric and shortcut selection and optional `rich` rendering.  
- Added many CLI utilities and commands including `netcheck`, `adb`, `clear-cache`, `doctor`, `logs`, `backups`, `reports`, exports (`*_json`), environment info (`_cmd_env`), cleanup helpers, and file enhancements (`push`/`delete`, optional local target for `pull`).  
- Extended database API with `get_recent_logs`, `get_recent_backups`, `get_recent_reports`, `get_recent_devices`, and `get_top_methods`, and updated `ReportGenerator.generate_device_report` to correctly name the report and call `db.track_event` for analytics.  
- Bumped version metadata to `6.0.1`, added input-length guarding using `Config.MAX_INPUT_LENGTH`, and added `last_device_id` support to default prompts and menu flows.

### Testing

- No automated unit tests or CI jobs were executed for these code changes.  
- Basic manual sanity edits were made (no automated test suite run).  
- Please run the project test suite and CI in your environment before merging.  
- Recommend running `void` CLI flows (e.g., `menu`, `devices`, `files pull/push/delete`, `report`) and DB queries to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d923aab60832ba5516803bf60366b)