### PR TITLE
Add plugin registry with CLI/GUI integration

### DIFF
--- a/void/plugins/__init__.py
+++ b/void/plugins/__init__.py
@@ -1,0 +1,14 @@
+"""Plugin package for Void."""
+
+from .base import PluginContext, PluginFeature, PluginMetadata, PluginResult
+from .registry import discover_plugins, get_registry, register_plugin
+
+__all__ = [
+    "PluginContext",
+    "PluginFeature",
+    "PluginMetadata",
+    "PluginResult",
+    "discover_plugins",
+    "get_registry",
+    "register_plugin",
+]

--- a/void/plugins/base.py
+++ b/void/plugins/base.py
@@ -1,0 +1,62 @@
+"""
+VOID Plugin Interface.
+
+Defines the stable contract for plugins and metadata.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Callable, Sequence
+
+
+@dataclass(frozen=True)
+class PluginMetadata:
+    """Metadata describing a plugin feature."""
+
+    id: str
+    name: str
+    description: str
+    version: str = "1.0.0"
+    author: str = "Void"
+    tags: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize metadata for structured outputs."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+            "author": self.author,
+            "tags": list(self.tags),
+        }
+
+
+@dataclass
+class PluginResult:
+    """Result returned from a plugin run."""
+
+    success: bool
+    message: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class PluginContext:
+    """Execution context for plugins."""
+
+    mode: str
+    emit: Callable[[str], None] | None = None
+
+
+class PluginFeature(ABC):
+    """Base class for all plugins."""
+
+    metadata: PluginMetadata
+
+    @abstractmethod
+    def run(self, context: PluginContext, args: Sequence[str]) -> PluginResult:
+        """Run the plugin feature."""
+        raise NotImplementedError

--- a/void/plugins/example.py
+++ b/void/plugins/example.py
@@ -1,0 +1,39 @@
+"""Example plugin shipped with Void."""
+
+from __future__ import annotations
+
+import platform
+from typing import Sequence
+
+from .base import PluginContext, PluginFeature, PluginMetadata, PluginResult
+from .registry import register_plugin
+
+
+@register_plugin
+class SystemInfoPlugin(PluginFeature):
+    """Sample plugin that reports host system information."""
+
+    metadata = PluginMetadata(
+        id="system-info",
+        name="System Info",
+        description="Report host OS and Python runtime details.",
+        version="1.0.0",
+        author="Void",
+        tags=("system", "example"),
+    )
+
+    def run(self, context: PluginContext, args: Sequence[str]) -> PluginResult:
+        details = {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "machine": platform.machine(),
+        }
+        message = (
+            "System Info\n"
+            f"OS: {details['platform']}\n"
+            f"Python: {details['python']}\n"
+            f"Machine: {details['machine']}"
+        )
+        if context.emit:
+            context.emit(message)
+        return PluginResult(success=True, message="System info collected.", data=details)

--- a/void/plugins/registry.py
+++ b/void/plugins/registry.py
@@ -1,0 +1,72 @@
+"""Plugin registry and discovery helpers."""
+
+from __future__ import annotations
+
+import importlib
+import pkgutil
+from typing import Dict, List, Sequence
+
+from .base import PluginContext, PluginFeature, PluginMetadata, PluginResult
+
+
+class PluginRegistry:
+    """Registry for plugin feature discovery and execution."""
+
+    def __init__(self) -> None:
+        self._plugins: Dict[str, PluginFeature] = {}
+
+    def register(self, plugin: PluginFeature) -> None:
+        """Register a plugin by its metadata id."""
+        plugin_id = plugin.metadata.id
+        if plugin_id in self._plugins:
+            raise ValueError(f"Plugin already registered: {plugin_id}")
+        self._plugins[plugin_id] = plugin
+
+    def list_metadata(self) -> List[PluginMetadata]:
+        """List plugin metadata sorted by name."""
+        return sorted(
+            (plugin.metadata for plugin in self._plugins.values()),
+            key=lambda meta: meta.name.lower(),
+        )
+
+    def get(self, plugin_id: str) -> PluginFeature | None:
+        """Get a plugin by id."""
+        return self._plugins.get(plugin_id)
+
+    def run(self, plugin_id: str, context: PluginContext, args: Sequence[str]) -> PluginResult:
+        """Execute a plugin by id."""
+        plugin = self.get(plugin_id)
+        if not plugin:
+            raise KeyError(f"Unknown plugin: {plugin_id}")
+        return plugin.run(context, args)
+
+
+_REGISTRY = PluginRegistry()
+_DISCOVERED = False
+
+
+def register_plugin(cls):
+    """Class decorator for registering plugins with a no-arg constructor."""
+    instance = cls()
+    _REGISTRY.register(instance)
+    return cls
+
+
+def get_registry() -> PluginRegistry:
+    """Return the global plugin registry."""
+    return _REGISTRY
+
+
+def discover_plugins() -> None:
+    """Discover plugins within the void.plugins package."""
+    global _DISCOVERED
+    if _DISCOVERED:
+        return
+
+    package = importlib.import_module("void.plugins")
+    for module_info in pkgutil.iter_modules(package.__path__, package.__name__ + "."):
+        if module_info.name.endswith(".base") or module_info.name.endswith(".registry"):
+            continue
+        importlib.import_module(module_info.name)
+
+    _DISCOVERED = True


### PR DESCRIPTION
### Motivation

- Provide a stable, discoverable plugin interface so CLI and GUI can expose and execute optional features dynamically.
- Enable third-party or internal feature extensions without changing core command routing or GUI layout.

### Description

- Add a new `void/plugins` package with `base.py` (defines `PluginMetadata`, `PluginContext`, `PluginResult`, and `PluginFeature`), `registry.py` (global `PluginRegistry`, `discover_plugins()`, and `register_plugin` decorator), `example.py` (a `system-info` example plugin), and `__init__.py` exports.
- Wire runtime discovery via `discover_plugins()` and a global registry accessible with `get_registry()` so features can be listed and executed using `PluginContext` and the registry `run` API.
- Integrate into the CLI by registering `plugins` and `plugin` commands and calling `discover_plugins()` in the CLI initialization to list (`plugins`) and run (`plugin <id> [args]`) plugins.
- Add a "Plugins" tab to the GUI that lists discovered plugins, shows metadata, and allows running a selected plugin with results logged to the GUI console.

### Testing

- No automated tests were executed for this change.
- Manual smoke: code was imported and a commit was created, but no unit or integration test suite was run.
- The new plugin example (`system-info`) is registered via the `@register_plugin` decorator and exercised by CLI/GUI integration points in code paths.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dcb66ee54832b9c0292f7204ee176)