### PR TITLE
Use structured logging across CLI/main/terms; add logs-export and filtered log query

### DIFF
--- a/void/core/__init__.py
+++ b/void/core/__init__.py
@@ -13,7 +13,7 @@ from .database import Database, db
 from .device import DeviceDetector
 from .frp import FRPEngine
 from .logcat import LogcatViewer
-from .logging import Logger, RICH_AVAILABLE, logger
+from .logging import Logger, logger
 from .monitor import PSUTIL_AVAILABLE, SystemMonitor, monitor
 from .network import NetworkAnalyzer, NetworkTools
 from .performance import PerformanceAnalyzer
@@ -37,7 +37,6 @@ __all__ = [
     'NetworkTools',
     'PSUTIL_AVAILABLE',
     'PerformanceAnalyzer',
-    'RICH_AVAILABLE',
     'ReportGenerator',
     'SafeSubprocess',
     'ScreenCapture',

--- a/void/core/logging.py
+++ b/void/core/logging.py
@@ -1,49 +1,29 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 
-from ..config import Config
+from ..logging import configure_logging
 from .database import db
-
-try:
-    from rich.console import Console
-
-    RICH_AVAILABLE = True
-except ImportError:
-    RICH_AVAILABLE = False
 
 
 class Logger:
     """Logging system"""
 
     def __init__(self):
-        self.console = Console() if RICH_AVAILABLE else None
-
-        log_file = Config.LOG_DIR / f"void_{datetime.now().strftime('%Y%m')}.log"
-        logging.basicConfig(
-            level=logging.DEBUG,
-            format='%(asctime)s - %(levelname)s - %(message)s',
-            handlers=[logging.FileHandler(log_file), logging.StreamHandler()],
-        )
-        self.logger = logging.getLogger('VoidSuite')
+        configure_logging()
+        self.logger = logging.getLogger("void")
 
     def log(self, level: str, category: str, message: str, device_id: str = None, method: str = None):
         """Log message"""
-        if self.console:
-            style = {
-                'debug': 'dim',
-                'info': 'green',
-                'warning': 'yellow',
-                'error': 'red bold',
-                'success': 'bold green',
-            }.get(level, 'white')
-            self.console.print(f"[{level.upper()}] {message}", style=style)
-        else:
-            print(f"[{level.upper()}] {message}")
-
-        log_method = getattr(self.logger, level if level != 'success' else 'info', self.logger.info)
-        log_method(message)
+        log_method = getattr(self.logger, level if level != "success" else "info", self.logger.info)
+        log_method(
+            message,
+            extra={
+                "category": category,
+                "device_id": device_id or "-",
+                "method": method or "-",
+            },
+        )
 
         try:
             db.log(level, category, message, device_id, method)

--- a/void/logging.py
+++ b/void/logging.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+
+from .config import Config
+
+_CONFIGURED = False
+
+
+class StructuredFormatter(logging.Formatter):
+    """Ensure structured fields are always present."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        for field in ("category", "device_id", "method"):
+            if not hasattr(record, field):
+                setattr(record, field, "-")
+        return super().format(record)
+
+
+def configure_logging(level: int = logging.DEBUG) -> None:
+    """Configure log handlers for file and console."""
+    global _CONFIGURED
+    if _CONFIGURED:
+        return
+
+    Config.setup()
+    log_file = Config.LOG_DIR / f"void_{datetime.now().strftime('%Y%m')}.log"
+
+    formatter = StructuredFormatter(
+        "%(asctime)s %(levelname)s %(name)s %(message)s "
+        "category=%(category)s device_id=%(device_id)s method=%(method)s"
+    )
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+
+    root_logger.addHandler(file_handler)
+    root_logger.addHandler(console_handler)
+
+    _CONFIGURED = True
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a configured logger."""
+    configure_logging()
+    return logging.getLogger(name)

--- a/void/terms.py
+++ b/void/terms.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from .config import Config
+from .logging import get_logger
 
 TERMS_TEXT = (
     "By using Void, you agree to the Terms & Conditions and confirm you have "
@@ -25,6 +26,7 @@ def terms_path() -> Path:
 
 def ensure_terms_acceptance_cli() -> bool:
     """Require user acceptance of Terms & Conditions before use (CLI)."""
+    logger = get_logger(__name__)
     terms_file = terms_path()
     if terms_file.exists():
         try:
@@ -34,11 +36,20 @@ def ensure_terms_acceptance_cli() -> bool:
         except Exception:
             pass
 
-    print("\n⚠️  TERMS & CONDITIONS REQUIRED\n")
-    print(TERMS_TEXT)
+    logger.warning(
+        "TERMS & CONDITIONS REQUIRED",
+        extra={"category": "terms", "device_id": "-", "method": "-"},
+    )
+    logger.info(
+        TERMS_TEXT,
+        extra={"category": "terms", "device_id": "-", "method": "-"},
+    )
     response = input("Type 'accept' to continue or anything else to exit: ").strip().lower()
     if response != "accept":
-        print("Terms not accepted. Exiting.")
+        logger.info(
+            "Terms not accepted. Exiting.",
+            extra={"category": "terms", "device_id": "-", "method": "-"},
+        )
         return False
 
     terms_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
### Motivation
- Centralize logging to produce consistent, structured output with metadata like `category`, `device_id`, and `method` for easier filtering and storage.  
- Replace ad-hoc `print()` usage in CLI and startup flows with the structured logger to keep console and file handlers in sync.  
- Provide operators a way to export filtered log data for analysis via a `logs-export` CLI command.  
- Enable SQL-level log filtering to support the export use case and future analytics needs.  

### Description
- Add `void/logging.py` with `configure_logging`, `get_logger`, and `StructuredFormatter` to ensure structured fields are always present.  
- Refactor `void/core/logging.py` to call `configure_logging()` and log with `extra={...}` while still persisting records to the DB via `db.log`.  
- Update `void/main.py`, `void/cli.py`, and `void/terms.py` to initialize/configure logging and replace direct `print()` calls with structured logger calls using `get_logger`.  
- Add `Database.get_filtered_logs` in `void/core/database.py` and a new `logs-export` command in `void/cli.py` to export filtered logs to `json` or `csv`.  

### Testing
- Ran the test suite with `pytest` and all automated tests completed successfully.  
- `pytest` reported `14 passed` and exited with code `0`.  
- No additional automated tests were added for the new CLI export feature in this change.  
- Manual/interactive behavior changes rely on existing tests and runtime logging initialization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd1ae2820832baa26057193e70e61)