### PR TITLE
Add chipset abstraction, detection dispatcher, and EDL/Test‑Point plugin

### DIFF
--- a/void/core/chipsets/__init__.py
+++ b/void/core/chipsets/__init__.py
@@ -1,0 +1,27 @@
+"""Chipset abstraction layer for device workflows."""
+
+from .base import BaseChipsetProtocol, ChipsetActionResult, ChipsetDetection
+from .dispatcher import (
+    detect_chipset_for_device,
+    enter_chipset_mode,
+    recover_chipset_device,
+    resolve_chipset,
+)
+from .generic import GenericChipset
+from .mediatek import MediaTekChipset
+from .qualcomm import QualcommChipset
+from .samsung import SamsungExynosChipset
+
+__all__ = [
+    "BaseChipsetProtocol",
+    "ChipsetActionResult",
+    "ChipsetDetection",
+    "detect_chipset_for_device",
+    "enter_chipset_mode",
+    "recover_chipset_device",
+    "resolve_chipset",
+    "GenericChipset",
+    "MediaTekChipset",
+    "QualcommChipset",
+    "SamsungExynosChipset",
+]

--- a/void/core/chipsets/base.py
+++ b/void/core/chipsets/base.py
@@ -1,0 +1,44 @@
+"""Base chipset protocol definitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class ChipsetDetection:
+    """Structured detection results from a chipset module."""
+
+    chipset: str
+    vendor: str
+    mode: str
+    confidence: float = 0.0
+    notes: tuple[str, ...] = ()
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ChipsetActionResult:
+    """Result of an action performed against a chipset workflow."""
+
+    success: bool
+    message: str
+    data: dict[str, str] = field(default_factory=dict)
+
+
+class BaseChipsetProtocol(Protocol):
+    """Protocol for chipset implementations."""
+
+    name: str
+    vendor: str
+    supported_modes: tuple[str, ...]
+
+    def detect(self, context: dict[str, str]) -> ChipsetDetection | None:
+        """Return detection info for the provided context."""
+
+    def enter_mode(self, context: dict[str, str], target_mode: str) -> ChipsetActionResult:
+        """Attempt to place the device into a target mode."""
+
+    def recover(self, context: dict[str, str]) -> ChipsetActionResult:
+        """Attempt a recovery workflow for the chipset."""

--- a/void/core/chipsets/dispatcher.py
+++ b/void/core/chipsets/dispatcher.py
@@ -1,0 +1,71 @@
+"""Dispatcher for chipset detection and workflows."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from .base import BaseChipsetProtocol, ChipsetActionResult, ChipsetDetection
+from .generic import GenericChipset
+from .mediatek import MediaTekChipset
+from .qualcomm import QualcommChipset
+from .samsung import SamsungExynosChipset
+
+
+_CHIPSET_IMPLEMENTATIONS: tuple[BaseChipsetProtocol, ...] = (
+    QualcommChipset(),
+    MediaTekChipset(),
+    SamsungExynosChipset(),
+    GenericChipset(),
+)
+
+
+def resolve_chipset(context: dict[str, str], override: str | None = None) -> BaseChipsetProtocol:
+    """Resolve a chipset implementation for the given context."""
+    if override:
+        for chipset in _CHIPSET_IMPLEMENTATIONS:
+            if chipset.name.lower() == override.lower():
+                return chipset
+        return GenericChipset()
+
+    detection = detect_chipset_for_device(context)
+    if detection:
+        for chipset in _CHIPSET_IMPLEMENTATIONS:
+            if chipset.name == detection.chipset:
+                return chipset
+    return GenericChipset()
+
+
+def detect_chipset_for_device(context: dict[str, str]) -> ChipsetDetection | None:
+    """Run chipset detection across known implementations."""
+    best: ChipsetDetection | None = None
+    for chipset in _CHIPSET_IMPLEMENTATIONS:
+        detection = chipset.detect(context)
+        if not detection:
+            continue
+        if not best or detection.confidence > best.confidence:
+            best = detection
+    return best
+
+
+def enter_chipset_mode(
+    context: dict[str, str],
+    target_mode: str,
+    override: str | None = None,
+) -> ChipsetActionResult:
+    """Dispatch an enter-mode request to the resolved chipset."""
+    chipset = resolve_chipset(context, override=override)
+    return chipset.enter_mode(context, target_mode)
+
+
+def recover_chipset_device(
+    context: dict[str, str],
+    override: str | None = None,
+) -> ChipsetActionResult:
+    """Dispatch a recovery request to the resolved chipset."""
+    chipset = resolve_chipset(context, override=override)
+    return chipset.recover(context)
+
+
+def list_chipsets() -> Iterable[BaseChipsetProtocol]:
+    """Return registered chipset implementations."""
+    return _CHIPSET_IMPLEMENTATIONS

--- a/void/core/chipsets/generic.py
+++ b/void/core/chipsets/generic.py
@@ -1,0 +1,37 @@
+"""Generic chipset placeholder."""
+
+from __future__ import annotations
+
+from .base import ChipsetActionResult, ChipsetDetection
+from .utils import normalize_text
+
+
+class GenericChipset:
+    """Fallback chipset with detection-only warnings."""
+
+    name = "Generic"
+    vendor = "Unknown"
+    supported_modes = ("adb", "fastboot")
+
+    def detect(self, context: dict[str, str]) -> ChipsetDetection | None:
+        mode = normalize_text(context.get("mode")) or "unknown"
+        return ChipsetDetection(
+            chipset=self.name,
+            vendor=self.vendor,
+            mode=mode,
+            confidence=0.1,
+            notes=("Generic chipset placeholder. Vendor tooling may be required.",),
+            metadata={},
+        )
+
+    def enter_mode(self, context: dict[str, str], target_mode: str) -> ChipsetActionResult:
+        return ChipsetActionResult(
+            success=False,
+            message="Generic chipset cannot enter modes automatically. Vendor tooling required.",
+        )
+
+    def recover(self, context: dict[str, str]) -> ChipsetActionResult:
+        return ChipsetActionResult(
+            success=False,
+            message="Generic chipset recovery unavailable. Vendor tooling required.",
+        )

--- a/void/core/chipsets/mediatek.py
+++ b/void/core/chipsets/mediatek.py
@@ -1,0 +1,83 @@
+"""MediaTek chipset workflows."""
+
+from __future__ import annotations
+
+from .base import ChipsetActionResult, ChipsetDetection
+from .utils import extract_usb_ids, match_any, normalize_text
+from ..utils import SafeSubprocess
+
+
+class MediaTekChipset:
+    """MediaTek preloader/bootrom workflows."""
+
+    name = "MediaTek"
+    vendor = "MediaTek"
+    supported_modes = ("adb", "fastboot", "preloader", "bootrom")
+
+    _MTK_VIDS = {"0e8d"}
+    _PRELOADER_PIDS = {"2000", "2001"}
+    _BOOTROM_PIDS = {"0003"}
+    _PLATFORM_TOKENS = ("mediatek", "mt", "mtk")
+
+    def detect(self, context: dict[str, str]) -> ChipsetDetection | None:
+        usb_ids = extract_usb_ids(context)
+        if usb_ids:
+            vid, pid = usb_ids
+            if vid in self._MTK_VIDS and pid in self._PRELOADER_PIDS:
+                return ChipsetDetection(
+                    chipset=self.name,
+                    vendor=self.vendor,
+                    mode="preloader",
+                    confidence=0.9,
+                    notes=("MediaTek preloader USB ID detected.",),
+                    metadata={"usb_vid": vid, "usb_pid": pid},
+                )
+            if vid in self._MTK_VIDS and pid in self._BOOTROM_PIDS:
+                return ChipsetDetection(
+                    chipset=self.name,
+                    vendor=self.vendor,
+                    mode="bootrom",
+                    confidence=0.9,
+                    notes=("MediaTek bootrom USB ID detected.",),
+                    metadata={"usb_vid": vid, "usb_pid": pid},
+                )
+
+        for key in ("chipset", "hardware", "product", "device", "bootloader"):
+            if match_any(context.get(key), self._PLATFORM_TOKENS):
+                return ChipsetDetection(
+                    chipset=self.name,
+                    vendor=self.vendor,
+                    mode=normalize_text(context.get("mode")) or "unknown",
+                    confidence=0.6,
+                    notes=(f"Matched MediaTek platform token in {key}.",),
+                    metadata={"matched_field": key},
+                )
+
+        return None
+
+    def enter_mode(self, context: dict[str, str], target_mode: str) -> ChipsetActionResult:
+        if target_mode.lower() not in {"preloader", "bootrom"}:
+            return ChipsetActionResult(
+                success=False,
+                message=f"MediaTek workflows support preloader/bootrom entry (requested {target_mode}).",
+            )
+
+        return ChipsetActionResult(
+            success=False,
+            message="MediaTek entry requires hardware key combos or a test-point trigger.",
+        )
+
+    def recover(self, context: dict[str, str]) -> ChipsetActionResult:
+        for tool in ("mtkclient", "spflashtool"):
+            code, stdout, stderr = SafeSubprocess.run(["which", tool])
+            if code == 0 and stdout.strip():
+                return ChipsetActionResult(
+                    success=True,
+                    message=f"MediaTek recovery tool '{tool}' is available for preloader/bootrom flows.",
+                    data={"tool": tool},
+                )
+
+        return ChipsetActionResult(
+            success=False,
+            message="No MediaTek recovery tools found (mtkclient/spflashtool).",
+        )

--- a/void/core/chipsets/qualcomm.py
+++ b/void/core/chipsets/qualcomm.py
@@ -1,0 +1,89 @@
+"""Qualcomm chipset workflows."""
+
+from __future__ import annotations
+
+from .base import ChipsetActionResult, ChipsetDetection
+from .utils import extract_usb_ids, match_any, normalize_text
+from ..utils import SafeSubprocess
+
+
+class QualcommChipset:
+    """Qualcomm EDL/Sahara/Firehose workflows."""
+
+    name = "Qualcomm"
+    vendor = "Qualcomm"
+    supported_modes = ("adb", "fastboot", "edl")
+
+    _QUALCOMM_VIDS = {"05c6"}
+    _QUALCOMM_PIDS = {"9008", "900e"}
+    _PLATFORM_TOKENS = ("qcom", "qualcomm", "msm", "sdm", "sm", "kona")
+
+    def detect(self, context: dict[str, str]) -> ChipsetDetection | None:
+        usb_ids = extract_usb_ids(context)
+        if usb_ids:
+            vid, pid = usb_ids
+            if vid in self._QUALCOMM_VIDS and pid in self._QUALCOMM_PIDS:
+                return ChipsetDetection(
+                    chipset=self.name,
+                    vendor=self.vendor,
+                    mode="edl",
+                    confidence=0.95,
+                    notes=("Qualcomm 9008 (EDL) USB ID detected.",),
+                    metadata={"usb_vid": vid, "usb_pid": pid},
+                )
+
+        for key in ("chipset", "hardware", "product", "device", "bootloader"):
+            if match_any(context.get(key), self._PLATFORM_TOKENS):
+                return ChipsetDetection(
+                    chipset=self.name,
+                    vendor=self.vendor,
+                    mode=normalize_text(context.get("mode")) or "unknown",
+                    confidence=0.65,
+                    notes=(f"Matched Qualcomm platform token in {key}.",),
+                    metadata={"matched_field": key},
+                )
+
+        return None
+
+    def enter_mode(self, context: dict[str, str], target_mode: str) -> ChipsetActionResult:
+        if target_mode.lower() != "edl":
+            return ChipsetActionResult(
+                success=False,
+                message=f"Qualcomm workflow only supports EDL entry (requested {target_mode}).",
+            )
+
+        device_id = context.get("id")
+        mode = normalize_text(context.get("mode"))
+        if device_id and mode == "adb":
+            code, _, stderr = SafeSubprocess.run(["adb", "-s", device_id, "reboot", "edl"])
+            if code == 0:
+                return ChipsetActionResult(
+                    success=True,
+                    message="ADB reboot to EDL issued.",
+                    data={"device_id": device_id},
+                )
+            return ChipsetActionResult(
+                success=False,
+                message="Failed to issue ADB reboot to EDL.",
+                data={"error": stderr or "unknown"},
+            )
+
+        return ChipsetActionResult(
+            success=False,
+            message="EDL entry requires ADB access or a manual test-point trigger.",
+        )
+
+    def recover(self, context: dict[str, str]) -> ChipsetActionResult:
+        for tool in ("edl", "qdl", "emmcdl"):
+            code, stdout, stderr = SafeSubprocess.run(["which", tool])
+            if code == 0 and stdout.strip():
+                return ChipsetActionResult(
+                    success=True,
+                    message=f"Qualcomm recovery tool '{tool}' is available for Sahara/Firehose flows.",
+                    data={"tool": tool},
+                )
+
+        return ChipsetActionResult(
+            success=False,
+            message="No Qualcomm recovery tools found (edl/qdl/emmcdl). Install a tool to proceed.",
+        )

--- a/void/core/chipsets/samsung.py
+++ b/void/core/chipsets/samsung.py
@@ -1,0 +1,57 @@
+"""Samsung Exynos chipset workflows."""
+
+from __future__ import annotations
+
+from .base import ChipsetActionResult, ChipsetDetection
+from .utils import extract_usb_ids, match_any, normalize_text
+
+
+class SamsungExynosChipset:
+    """Samsung Exynos download/odin workflows."""
+
+    name = "Samsung Exynos"
+    vendor = "Samsung"
+    supported_modes = ("adb", "fastboot", "download", "odin")
+
+    _SAMSUNG_VIDS = {"04e8"}
+    _DOWNLOAD_PIDS = {"685d", "6860"}
+    _PLATFORM_TOKENS = ("exynos", "samsung", "universal")
+
+    def detect(self, context: dict[str, str]) -> ChipsetDetection | None:
+        usb_ids = extract_usb_ids(context)
+        if usb_ids:
+            vid, pid = usb_ids
+            if vid in self._SAMSUNG_VIDS and pid in self._DOWNLOAD_PIDS:
+                return ChipsetDetection(
+                    chipset=self.name,
+                    vendor=self.vendor,
+                    mode="download",
+                    confidence=0.9,
+                    notes=("Samsung download mode USB ID detected.",),
+                    metadata={"usb_vid": vid, "usb_pid": pid},
+                )
+
+        for key in ("chipset", "hardware", "product", "device", "bootloader", "manufacturer"):
+            if match_any(context.get(key), self._PLATFORM_TOKENS):
+                return ChipsetDetection(
+                    chipset=self.name,
+                    vendor=self.vendor,
+                    mode=normalize_text(context.get("mode")) or "unknown",
+                    confidence=0.55,
+                    notes=(f"Matched Samsung/Exynos platform token in {key}.",),
+                    metadata={"matched_field": key},
+                )
+
+        return None
+
+    def enter_mode(self, context: dict[str, str], target_mode: str) -> ChipsetActionResult:
+        return ChipsetActionResult(
+            success=False,
+            message="Samsung download/odin workflows require vendor tooling and user confirmation.",
+        )
+
+    def recover(self, context: dict[str, str]) -> ChipsetActionResult:
+        return ChipsetActionResult(
+            success=False,
+            message="Samsung Exynos recovery requires vendor-provided tooling.",
+        )

--- a/void/core/chipsets/utils.py
+++ b/void/core/chipsets/utils.py
@@ -1,0 +1,31 @@
+"""Utilities for chipset detection."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def normalize_text(value: str | None) -> str:
+    """Normalize text for matching."""
+    return (value or "").strip().lower()
+
+
+def match_any(value: str | None, tokens: Iterable[str]) -> bool:
+    """Return True when value contains any token."""
+    haystack = normalize_text(value)
+    return any(token in haystack for token in tokens)
+
+
+def extract_usb_ids(context: dict[str, str]) -> tuple[str, str] | None:
+    """Extract USB VID/PID from context."""
+    vid = normalize_text(context.get("usb_vid") or context.get("vid"))
+    pid = normalize_text(context.get("usb_pid") or context.get("pid"))
+    if vid and pid:
+        return vid, pid
+
+    combined = normalize_text(context.get("usb_id") or context.get("usb"))
+    if combined and ":" in combined:
+        parts = combined.split(":", 1)
+        if len(parts) == 2:
+            return parts[0], parts[1]
+    return None

--- a/void/plugins/edl_testpoint.py
+++ b/void/plugins/edl_testpoint.py
@@ -1,0 +1,80 @@
+"""EDL/Test-Point workflow plugin."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from void.core.chipsets.dispatcher import (
+    detect_chipset_for_device,
+    enter_chipset_mode,
+    recover_chipset_device,
+)
+
+from .base import PluginContext, PluginFeature, PluginMetadata, PluginResult
+from .registry import register_plugin
+
+
+@register_plugin
+class EDLTestPointPlugin(PluginFeature):
+    """Plugin entry point for EDL/Test-Point workflows."""
+
+    metadata = PluginMetadata(
+        id="edl-testpoint",
+        name="EDL/Test-Point",
+        description="Chipset-aware entry and recovery flows for EDL/Test-Point.",
+        version="1.0.0",
+        author="Void",
+        tags=("chipset", "edl", "recovery", "cli", "gui"),
+    )
+
+    def run(self, context: PluginContext, args: Sequence[str]) -> PluginResult:
+        request = "detect"
+        target_mode = "edl"
+        override = None
+        device_id = None
+        mode = context.mode
+
+        for arg in args:
+            if arg.startswith("--mode="):
+                target_mode = arg.split("=", 1)[1]
+            elif arg.startswith("--override="):
+                override = arg.split("=", 1)[1]
+            elif arg.startswith("--device="):
+                device_id = arg.split("=", 1)[1]
+            elif arg in {"detect", "enter", "recover"}:
+                request = arg
+
+        device_context = {
+            "id": device_id or "",
+            "mode": mode,
+        }
+
+        if request == "detect":
+            detection = detect_chipset_for_device(device_context)
+            if not detection:
+                return PluginResult(success=False, message="No chipset detected.")
+            if context.emit:
+                context.emit(
+                    f"Detected chipset: {detection.chipset} "
+                    f"({detection.vendor}) mode={detection.mode}"
+                )
+            return PluginResult(
+                success=True,
+                message="Chipset detection complete.",
+                data={
+                    "chipset": detection.chipset,
+                    "vendor": detection.vendor,
+                    "mode": detection.mode,
+                    "confidence": str(detection.confidence),
+                },
+            )
+
+        if request == "enter":
+            result = enter_chipset_mode(device_context, target_mode, override=override)
+        else:
+            result = recover_chipset_device(device_context, override=override)
+
+        if context.emit:
+            context.emit(result.message)
+
+        return PluginResult(success=result.success, message=result.message, data=result.data)


### PR DESCRIPTION
### Motivation
- Provide a unified chipset abstraction to support detection, entry-mode and recovery workflows across vendors.
- Surface low-level USB modes (EDL/preloader/download) and chipset metadata to the device detection pipeline for better tooling decisions.
- Offer vendor-specific handling for common platforms (Qualcomm, MediaTek, Samsung Exynos) while falling back to a generic placeholder.
- Expose EDL/Test‑Point workflows via the plugin system for CLI/GUI integration.

### Description
- Add a new chipset package `void/core/chipsets` with `base.py` (protocols), `dispatcher.py` (resolver/dispatcher), `utils.py`, and implementations `qualcomm.py`, `mediatek.py`, `samsung.py`, and `generic.py`.
- Implement a dispatcher API with `detect_chipset_for_device`, `resolve_chipset`, `enter_chipset_mode`, and `recover_chipset_device` and register known implementations.
- Integrate chipset detection into `DeviceDetector.detect_all()` by adding `DeviceDetector._detect_usb_modes()`, `_classify_usb_mode()`, and `_attach_chipset_metadata()` to parse `lsusb` output and attach `chipset` metadata to device records.
- Add a plugin `void/plugins/edl_testpoint.py` that registers `edl-testpoint` and exposes `detect`, `enter`, and `recover` actions using the new dispatcher and chipset workflows.

### Testing
- No automated tests were executed for these changes.
- Manual validation was not recorded in this PR description.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd7437db0832b9abb33316db682fa)