### PR TITLE
Add EDL CLI commands, chipset tool wrappers, and structured EDL logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ void> analyze emulator-5554
 void> report emulator-5554
 void> logcat emulator-5554
 void> execute adb_shell_reset emulator-5554
+void> edl-status usb-05c6:9008
+void> edl-enter emulator-5554
+void> edl-flash usb-05c6:9008 firehose.mbn boot.img
+void> edl-dump usb-05c6:9008 userdata
+void> testpoint-guide usb-05c6:9008
 ```
 
 ## GUI Usage
@@ -125,6 +130,13 @@ void --gui
   - `logs` / `backups` / `reports` / `exports`
   - `help`
   - `exit`
+
+- **EDL & test-point**
+  - `edl-status <device_id>`
+  - `edl-enter <device_id>`
+  - `edl-flash <device_id> <loader> <image>`
+  - `edl-dump <device_id> <partition>`
+  - `testpoint-guide <device_id>`
 
 ## Troubleshooting
 

--- a/void/core/edl.py
+++ b/void/core/edl.py
@@ -1,0 +1,121 @@
+"""EDL tool wrappers for chipset-aware workflows."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from .chipsets.base import ChipsetActionResult
+from .chipsets.dispatcher import detect_chipset_for_device
+from .config import Config
+from .utils import SafeSubprocess
+
+
+_QUALCOMM_TOOLS = ("qdl", "edl", "emmcdl")
+
+
+def _find_tool(candidates: tuple[str, ...]) -> str | None:
+    for tool in candidates:
+        code, stdout, _ = SafeSubprocess.run(["which", tool])
+        if code == 0 and stdout.strip():
+            return tool
+    return None
+
+
+def _build_flash_command(tool: str, loader: str, image: str) -> list[str] | None:
+    if tool == "qdl":
+        return [tool, "--loader", loader, "--storage", "emmc", image]
+    if tool == "edl":
+        return [tool, "--loader", loader, "--flash", image]
+    if tool == "emmcdl":
+        return [tool, "-f", loader, "-i", image]
+    return None
+
+
+def _build_dump_command(tool: str, partition: str, output: Path) -> list[str] | None:
+    if tool == "edl":
+        return [tool, "--read", partition, "--output", str(output)]
+    if tool == "emmcdl":
+        return [tool, "-d", partition, "-o", str(output)]
+    return None
+
+
+def edl_flash(context: dict[str, str], loader: str, image: str) -> ChipsetActionResult:
+    """Attempt an EDL flash using chipset-specific tooling."""
+    detection = detect_chipset_for_device(context)
+    if not detection or detection.chipset != "Qualcomm":
+        chipset = detection.chipset if detection else "Unknown"
+        return ChipsetActionResult(
+            success=False,
+            message=f"EDL flash is only supported for Qualcomm devices (detected {chipset}).",
+        )
+
+    tool = _find_tool(_QUALCOMM_TOOLS)
+    if not tool:
+        return ChipsetActionResult(
+            success=False,
+            message="No Qualcomm EDL tooling found (qdl/edl/emmcdl). Install one to proceed.",
+        )
+
+    command = _build_flash_command(tool, loader, image)
+    if not command:
+        return ChipsetActionResult(
+            success=False,
+            message=f"Tool '{tool}' does not support flash operations in this wrapper.",
+        )
+
+    code, _, stderr = SafeSubprocess.run(command)
+    if code == 0:
+        return ChipsetActionResult(
+            success=True,
+            message=f"EDL flash issued via {tool}.",
+            data={"tool": tool, "command": " ".join(command)},
+        )
+    return ChipsetActionResult(
+        success=False,
+        message="EDL flash failed.",
+        data={"tool": tool, "error": stderr or "unknown", "command": " ".join(command)},
+    )
+
+
+def edl_dump(context: dict[str, str], partition: str) -> ChipsetActionResult:
+    """Attempt an EDL partition dump using chipset-specific tooling."""
+    detection = detect_chipset_for_device(context)
+    if not detection or detection.chipset != "Qualcomm":
+        chipset = detection.chipset if detection else "Unknown"
+        return ChipsetActionResult(
+            success=False,
+            message=f"EDL dump is only supported for Qualcomm devices (detected {chipset}).",
+        )
+
+    tool = _find_tool(_QUALCOMM_TOOLS)
+    if not tool:
+        return ChipsetActionResult(
+            success=False,
+            message="No Qualcomm EDL tooling found (qdl/edl/emmcdl). Install one to proceed.",
+        )
+
+    Config.setup()
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_partition = partition.replace("/", "_")
+    output = Config.EXPORTS_DIR / f"edl_dump_{safe_partition}_{timestamp}.bin"
+
+    command = _build_dump_command(tool, partition, output)
+    if not command:
+        return ChipsetActionResult(
+            success=False,
+            message=f"Tool '{tool}' does not support dump operations in this wrapper.",
+        )
+
+    code, _, stderr = SafeSubprocess.run(command)
+    if code == 0:
+        return ChipsetActionResult(
+            success=True,
+            message=f"EDL dump issued via {tool}.",
+            data={"tool": tool, "command": " ".join(command), "output": str(output)},
+        )
+    return ChipsetActionResult(
+        success=False,
+        message="EDL dump failed.",
+        data={"tool": tool, "error": stderr or "unknown", "command": " ".join(command)},
+    )

--- a/void/logging.py
+++ b/void/logging.py
@@ -51,3 +51,29 @@ def get_logger(name: str) -> logging.Logger:
     """Return a configured logger."""
     configure_logging()
     return logging.getLogger(name)
+
+
+def log_edl_event(
+    logger: logging.Logger,
+    action: str,
+    device_id: str | None,
+    message: str,
+    *,
+    success: bool | None = None,
+    details: dict[str, str] | None = None,
+) -> None:
+    """Emit a structured log entry for EDL workflows."""
+    extra = {
+        "category": "edl",
+        "device_id": device_id or "-",
+        "method": action,
+    }
+    if details:
+        detail_str = " ".join(f"{key}={value}" for key, value in details.items())
+        message = f"{message} ({detail_str})"
+    if success is None:
+        logger.info(message, extra=extra)
+    elif success:
+        logger.info(message, extra=extra)
+    else:
+        logger.error(message, extra=extra)


### PR DESCRIPTION
### Motivation

- Expose EDL and test-point workflows from the interactive CLI so users can detect, enter, flash, and dump low-level device modes via a common interface.
- Centralize Qualcomm EDL tooling discovery and command construction to make flash/dump operations chipset-aware and reduce duplicated logic.
- Capture EDL operations with structured logs for easier auditing and debugging of sensitive device operations.
- Document usage examples so the new commands are discoverable from the README and CLI help.

### Description

- Added `void/core/edl.py` with wrapper functions `edl_flash` and `edl_dump`, tool discovery (`which`), command builders for `qdl|edl|emmcdl`, and safe output naming for dumps.
- Introduced `log_edl_event` in `void/logging.py` to emit structured log entries containing `category=edl`, `device_id`, `method`, and optional `details`.
- Extended `void/cli.py` to register and implement the new commands: `edl-status`, `edl-enter`, `edl-flash`, `edl-dump`, and `testpoint-guide`, wired to the chipset dispatcher (`detect_chipset_for_device`, `enter_chipset_mode`) and the new EDL wrappers, and added help/examples to the CLI help text.
- Updated `README.md` to include CLI examples and a command list for the new EDL/test-point commands.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd87d7f84832b8ceb69a85a2b70d9)