### PR TITLE
Add external tool wrappers and doctor tooling report

### DIFF
--- a/void/core/tools/__init__.py
+++ b/void/core/tools/__init__.py
@@ -1,0 +1,21 @@
+"""External tool wrappers."""
+
+from __future__ import annotations
+
+from .android import check_android_tools, resolve_android_fallback
+from .mediatek import (
+    build_sp_flash_script_command,
+    check_mediatek_tools,
+    resolve_mediatek_recovery_tool,
+)
+from .qualcomm import check_qualcomm_tools, resolve_qualcomm_recovery_tool
+
+__all__ = [
+    "build_sp_flash_script_command",
+    "check_android_tools",
+    "check_mediatek_tools",
+    "check_qualcomm_tools",
+    "resolve_android_fallback",
+    "resolve_mediatek_recovery_tool",
+    "resolve_qualcomm_recovery_tool",
+]

--- a/void/core/tools/android.py
+++ b/void/core/tools/android.py
@@ -1,0 +1,22 @@
+"""ADB/Fastboot tool wrappers."""
+
+from __future__ import annotations
+
+from .base import ToolSpec, check_tool_specs, first_available
+from ..utils import ToolCheckResult
+
+
+ADB_SPEC = ToolSpec(name="adb", version_args=("version",), label="ADB")
+FASTBOOT_SPEC = ToolSpec(name="fastboot", version_args=("--version",), label="Fastboot")
+
+
+def check_android_tools() -> list[ToolCheckResult]:
+    """Return validation results for Android platform tools."""
+    return check_tool_specs((ADB_SPEC, FASTBOOT_SPEC))
+
+
+def resolve_android_fallback() -> tuple[str | None, list[ToolCheckResult]]:
+    """Return the preferred available Android tool as a fallback."""
+    results = check_android_tools()
+    selected = first_available(results)
+    return (selected.name if selected else None, results)

--- a/void/core/tools/base.py
+++ b/void/core/tools/base.py
@@ -1,0 +1,35 @@
+"""Shared helpers for external tool wrappers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+from ..utils import ToolCheckResult, check_tool
+
+
+@dataclass(frozen=True)
+class ToolSpec:
+    """Specification for an external tool and its version arguments."""
+
+    name: str
+    version_args: tuple[str, ...] = ()
+    label: str | None = None
+
+
+def check_tool_spec(spec: ToolSpec) -> ToolCheckResult:
+    """Validate a tool spec."""
+    return check_tool(spec.name, spec.version_args or None)
+
+
+def check_tool_specs(specs: Iterable[ToolSpec]) -> list[ToolCheckResult]:
+    """Validate multiple tool specs."""
+    return [check_tool_spec(spec) for spec in specs]
+
+
+def first_available(results: Sequence[ToolCheckResult]) -> ToolCheckResult | None:
+    """Return the first available tool result."""
+    for result in results:
+        if result.available:
+            return result
+    return None

--- a/void/core/tools/mediatek.py
+++ b/void/core/tools/mediatek.py
@@ -1,0 +1,49 @@
+"""MediaTek tool wrappers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .android import resolve_android_fallback
+from .base import ToolSpec, check_tool_specs, first_available
+from ..utils import ToolCheckResult
+
+
+MTKCLIENT_SPEC = ToolSpec(name="mtkclient", version_args=("--version",), label="mtkclient")
+SP_FLASH_SPECS = (
+    ToolSpec(name="spflashtool", version_args=("--version",), label="SP Flash Tool"),
+    ToolSpec(name="flash_tool", version_args=("--version",), label="SP Flash Tool"),
+)
+
+
+def check_mediatek_tools() -> list[ToolCheckResult]:
+    """Return validation results for MediaTek tooling."""
+    return check_tool_specs((MTKCLIENT_SPEC, *SP_FLASH_SPECS))
+
+
+def resolve_mediatek_recovery_tool() -> tuple[str | None, dict]:
+    """Pick a MediaTek recovery tool with structured error info."""
+    results = check_mediatek_tools()
+    selected = first_available(results)
+    if selected:
+        return selected.name, {"results": results}
+
+    fallback_name, fallback_results = resolve_android_fallback()
+    error = {
+        "code": "tool_missing",
+        "message": "No MediaTek recovery tools found (mtkclient/SP Flash Tool).",
+        "candidates": [MTKCLIENT_SPEC.name, *(spec.name for spec in SP_FLASH_SPECS)],
+    }
+    if fallback_name:
+        error["fallback"] = fallback_name
+
+    return None, {"error": error, "results": results, "fallback_results": fallback_results}
+
+
+def build_sp_flash_script_command(script_path: Path) -> list[str] | None:
+    """Build a SP Flash Tool command for script-based flashing when available."""
+    results = check_tool_specs(SP_FLASH_SPECS)
+    selected = first_available(results)
+    if not selected:
+        return None
+    return [selected.name, "--script", str(script_path)]

--- a/void/core/tools/qualcomm.py
+++ b/void/core/tools/qualcomm.py
@@ -1,0 +1,38 @@
+"""Qualcomm tool wrappers."""
+
+from __future__ import annotations
+
+from .android import resolve_android_fallback
+from .base import ToolSpec, check_tool_specs, first_available
+from ..utils import ToolCheckResult
+
+
+QUALCOMM_SPECS = (
+    ToolSpec(name="edl", version_args=("--version",), label="edl"),
+    ToolSpec(name="qdl", version_args=("--version",), label="qdl"),
+    ToolSpec(name="emmcdl", version_args=("--version",), label="emmcdl"),
+)
+
+
+def check_qualcomm_tools() -> list[ToolCheckResult]:
+    """Return validation results for Qualcomm tooling."""
+    return check_tool_specs(QUALCOMM_SPECS)
+
+
+def resolve_qualcomm_recovery_tool() -> tuple[str | None, dict]:
+    """Pick a Qualcomm recovery tool with structured error info."""
+    results = check_qualcomm_tools()
+    selected = first_available(results)
+    if selected:
+        return selected.name, {"results": results}
+
+    fallback_name, fallback_results = resolve_android_fallback()
+    error = {
+        "code": "tool_missing",
+        "message": "No Qualcomm recovery tools found (edl/qdl/emmcdl).",
+        "candidates": [spec.name for spec in QUALCOMM_SPECS],
+    }
+    if fallback_name:
+        error["fallback"] = fallback_name
+
+    return None, {"error": error, "results": results, "fallback_results": fallback_results}

--- a/void/core/utils.py
+++ b/void/core/utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from dataclasses import dataclass, field
+import shutil
 import subprocess
-from typing import List, Tuple
+from typing import Iterable, List, Sequence, Tuple
 
 from ..config import Config
 
@@ -25,3 +27,54 @@ class SafeSubprocess:
             return -1, "", "Timeout"
         except Exception as exc:
             return -1, "", str(exc)
+
+
+@dataclass(frozen=True)
+class ToolCheckResult:
+    """Result of validating an external tool."""
+
+    name: str
+    available: bool
+    path: str | None = None
+    version: str | None = None
+    error: dict[str, str] = field(default_factory=dict)
+
+
+def check_tool(name: str, version_args: Sequence[str] | None = None) -> ToolCheckResult:
+    """Validate a tool is on PATH and optionally resolve its version."""
+    path = shutil.which(name)
+    if not path:
+        return ToolCheckResult(
+            name=name,
+            available=False,
+            error={
+                "code": "tool_missing",
+                "message": f"{name} not found in PATH.",
+            },
+        )
+
+    version = None
+    error: dict[str, str] = {}
+    if version_args:
+        code, stdout, stderr = SafeSubprocess.run([name, *version_args])
+        output = (stdout or stderr).strip()
+        if code == 0 and output:
+            version = output.splitlines()[0].strip()
+        elif code != 0:
+            error = {
+                "code": "version_check_failed",
+                "message": output or f"Unable to determine {name} version.",
+            }
+
+    return ToolCheckResult(
+        name=name,
+        available=True,
+        path=path,
+        version=version,
+        error=error,
+    )
+
+
+def check_tools(tools: Iterable[tuple[str, Sequence[str] | None]]) -> List[ToolCheckResult]:
+    """Validate a list of tools from (name, version_args) tuples."""
+    return [check_tool(name, version_args) for name, version_args in tools]


### PR DESCRIPTION
### Motivation

- Provide a central place to validate and wrap external platform tools (Qualcomm, MediaTek, Android) used by chipset flows.
- Surface structured error messages and version information instead of ad-hoc `which`/`subprocess` checks scattered across the codebase.
- Improve recovery workflow selection by picking an available tool or returning clear fallback information.

### Description

- Add `void/core/tools/` with `base.py`, `android.py`, `qualcomm.py`, `mediatek.py`, and `__init__.py` providing `ToolSpec` helpers, tool checks, resolution and fallback logic.
- Introduce `ToolCheckResult`, `check_tool`, and `check_tools` in `void/core/utils.py` to centralize tool presence and version probing with structured error metadata.
- Update `void/core/chipsets/qualcomm.py` and `void/core/chipsets/mediatek.py` to use the new tool resolvers and return richer `ChipsetActionResult` data and errors.
- Extend the CLI `doctor` command in `void/cli.py` to report Android/Qualcomm/MediaTek tooling availability and version information in a readable format.

### Testing

- No automated tests were executed as part of this change.
- Changes were exercised by static inspection and local commit; further unit/integration tests are recommended to validate tool detection across environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd9bf437c832bb2752bd0841a6d6d)