### PR TITLE
Add destructive-action confirmations and audit logging

### DIFF
--- a/void/logging.py
+++ b/void/logging.py
@@ -12,7 +12,15 @@ class StructuredFormatter(logging.Formatter):
     """Ensure structured fields are always present."""
 
     def format(self, record: logging.LogRecord) -> str:
-        for field in ("category", "device_id", "method"):
+        for field in (
+            "category",
+            "device_id",
+            "method",
+            "action",
+            "confirmed",
+            "interface",
+            "step",
+        ):
             if not hasattr(record, field):
                 setattr(record, field, "-")
         return super().format(record)
@@ -32,6 +40,12 @@ def configure_logging(level: int = logging.DEBUG) -> None:
         "category=%(category)s device_id=%(device_id)s method=%(method)s"
     )
 
+    audit_formatter = StructuredFormatter(
+        "%(asctime)s %(levelname)s %(name)s %(message)s "
+        "category=%(category)s device_id=%(device_id)s method=%(method)s "
+        "action=%(action)s confirmed=%(confirmed)s interface=%(interface)s step=%(step)s"
+    )
+
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
 
@@ -44,6 +58,14 @@ def configure_logging(level: int = logging.DEBUG) -> None:
     root_logger.addHandler(file_handler)
     root_logger.addHandler(console_handler)
 
+    audit_file = Config.LOG_DIR / f"void_audit_{datetime.now().strftime('%Y%m')}.log"
+    audit_handler = logging.FileHandler(audit_file, encoding="utf-8")
+    audit_handler.setFormatter(audit_formatter)
+    audit_logger = logging.getLogger("void.audit")
+    audit_logger.setLevel(logging.INFO)
+    audit_logger.addHandler(audit_handler)
+    audit_logger.propagate = False
+
     _CONFIGURED = True
 
 
@@ -51,3 +73,28 @@ def get_logger(name: str) -> logging.Logger:
     """Return a configured logger."""
     configure_logging()
     return logging.getLogger(name)
+
+
+def log_user_confirmation(
+    action: str,
+    confirmed: bool,
+    device_id: str = "-",
+    method: str = "-",
+    interface: str = "cli",
+    step: str = "primary",
+) -> None:
+    """Log a user confirmation decision to the audit trail."""
+    configure_logging()
+    audit_logger = logging.getLogger("void.audit")
+    audit_logger.info(
+        f"User confirmation {step} recorded for {action}.",
+        extra={
+            "category": "audit",
+            "device_id": device_id,
+            "method": method,
+            "action": action,
+            "confirmed": str(confirmed),
+            "interface": interface,
+            "step": step,
+        },
+    )

--- a/void/terms.py
+++ b/void/terms.py
@@ -12,12 +12,17 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from .config import Config
-from .logging import get_logger
+from .logging import get_logger, log_user_confirmation
 
 TERMS_TEXT = (
     "By using Void, you agree to the Terms & Conditions and confirm you have "
     "authorization to access any connected device."
 )
+
+DESTRUCTIVE_ACTIONS = {
+    "edl_flash": "EDL flash",
+    "partition_dump": "partition dump",
+}
 
 
 def terms_path() -> Path:
@@ -77,4 +82,101 @@ def ensure_terms_acceptance_gui(messagebox) -> bool:
 
     terms_file.parent.mkdir(parents=True, exist_ok=True)
     terms_file.write_text(json.dumps({"accepted": True}))
+    return True
+
+
+def _requires_double_confirmation(action: str) -> bool:
+    return action in DESTRUCTIVE_ACTIONS
+
+
+def _action_label(action: str) -> str:
+    return DESTRUCTIVE_ACTIONS.get(action, action.replace("_", " "))
+
+
+def confirm_destructive_action_cli(
+    action: str,
+    device_id: str = "-",
+    method: str = "-",
+    interface: str = "cli",
+) -> bool:
+    """Confirm destructive actions on the CLI with explicit acknowledgement."""
+    label = _action_label(action)
+    prompt = (
+        f"⚠️  Destructive action requested: {label}. "
+        "Type 'confirm' to continue or anything else to cancel: "
+    )
+    response = input(prompt).strip().lower()
+    confirmed = response == "confirm"
+    log_user_confirmation(
+        action,
+        confirmed,
+        device_id=device_id,
+        method=method,
+        interface=interface,
+        step="primary",
+    )
+    if not confirmed:
+        return False
+
+    if _requires_double_confirmation(action):
+        second_prompt = (
+            f"Final confirmation required for {label}. "
+            "Type 'I UNDERSTAND' to proceed: "
+        )
+        second_response = input(second_prompt).strip().lower()
+        secondary_confirmed = second_response == "i understand"
+        log_user_confirmation(
+            action,
+            secondary_confirmed,
+            device_id=device_id,
+            method=method,
+            interface=interface,
+            step="secondary",
+        )
+        return secondary_confirmed
+
+    return True
+
+
+def confirm_destructive_action_gui(
+    messagebox,
+    action: str,
+    device_id: str = "-",
+    method: str = "-",
+    interface: str = "gui",
+) -> bool:
+    """Confirm destructive actions in the GUI with a secondary prompt."""
+    label = _action_label(action)
+    confirmed = messagebox.askyesno(
+        "Confirm Destructive Action",
+        f"This action will perform {label} on a connected device.\n\n"
+        "Do you want to continue?",
+    )
+    log_user_confirmation(
+        action,
+        confirmed,
+        device_id=device_id,
+        method=method,
+        interface=interface,
+        step="primary",
+    )
+    if not confirmed:
+        return False
+
+    if _requires_double_confirmation(action):
+        secondary = messagebox.askyesno(
+            "Final Confirmation Required",
+            f"{label} is highly destructive and may overwrite or expose data.\n\n"
+            "I understand the risks and want to continue.",
+        )
+        log_user_confirmation(
+            action,
+            secondary,
+            device_id=device_id,
+            method=method,
+            interface=interface,
+            step="secondary",
+        )
+        return secondary
+
     return True


### PR DESCRIPTION
### Motivation

- Require stronger safeguards for high-risk operations (EDL flash, partition dump) by introducing explicit confirmations.
- Prevent accidental invocation of destructive tooling from both CLI and GUI by adding guard checks before plugin/tool execution.
- Record user decisions for audit and incident investigation by extending logging to capture confirmation events.

### Description

- Added structured audit fields and an `void.audit` audit logger in `void/logging.py`, plus a helper `log_user_confirmation()` to write confirmation events to a dedicated audit log file.
- Implemented explicit confirmation flows in `void/terms.py`: `confirm_destructive_action_cli()` and `confirm_destructive_action_gui()` with primary and (for certain actions) secondary confirmations, and a `DESTRUCTIVE_ACTIONS` map.
- Added CLI protections in `void/cli.py` that infer destructive actions for plugin runs and call `confirm_destructive_action_cli()` before executing a plugin (including device-id extraction helper and destructive-action inference logic).
- Added corresponding GUI protections in `void/gui.py` that infer destructive actions for plugin runs and call `confirm_destructive_action_gui()` with a non-intrusive device peek and user-facing cancellation handling.

### Testing

- No automated tests were run as part of this change.
- Manual validation was not recorded by automated test harness (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694dd9f89440832ba47310c40d13f97d)