### PR TITLE
Fix package discovery for builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,6 @@ gui = []
 
 [project.scripts]
 void = "void.main:main"
+
+[tool.setuptools]
+packages = ["void"]


### PR DESCRIPTION
### Motivation
- Building the project with `pip install .` failed due to setuptools detecting multiple top-level packages in a flat layout and aborting with a `Multiple top-level packages discovered` error.
- The repository contains unrelated top-level files that can be accidentally picked up by automatic discovery, so discovery must be constrained.
- Explicitly declaring the package list ensures predictable wheels and avoids accidental inclusion of non-package files.

### Description
- Added a `[tool.setuptools]` section to `pyproject.toml` with `packages = ["void"]` to explicitly restrict package discovery to the `void` package.
- This change targets the flat layout of the repo and prevents setuptools from discovering other top-level names.
- Modified file: `pyproject.toml`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694decf203dc832bb743eb959902bb2c)