### PR TITLE
Fix packaging to include void submodules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,4 +17,10 @@ gui = []
 void = "void.main:main"
 
 [tool.setuptools]
-packages = ["void"]
+packages = [
+    "void",
+    "void.core",
+    "void.core.chipsets",
+    "void.core.tools",
+    "void.plugins",
+]


### PR DESCRIPTION
### Motivation
- Installing the package failed to import `void.core` because subpackages were not included in the setuptools package list. 
- The `[tool.setuptools]` section only listed `"void"`, which prevented installed distribution from exposing nested modules used by the CLI script `void`.

### Description
- Updated `pyproject.toml` `[tool.setuptools]` `packages` entry to explicitly include `void.core`, `void.core.chipsets`, `void.core.tools`, and `void.plugins` alongside `void`.
- No other code changes were made.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df0bc60f4832b917179fb43857748)