### PR TITLE
Fix EDL Config import path

### DIFF
--- a/void/core/edl.py
+++ b/void/core/edl.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from .chipsets.base import ChipsetActionResult
 from .chipsets.dispatcher import detect_chipset_for_device
-from .config import Config
+from ..config import Config
 from .utils import SafeSubprocess
 
 


### PR DESCRIPTION
### Motivation
- Running the installed package raised `ModuleNotFoundError: No module named 'void.core.config'` due to an incorrect relative import in `void/core/edl.py`.
- The EDL helper should import the package-level `Config` the same way other core modules do to work both in-source and when installed.

### Description
- Updated the import in `void/core/edl.py` from `from .config import Config` to `from ..config import Config`.
- This is a single-line fix and does not change any runtime logic or behavior beyond resolving the import path.

### Testing
- No automated tests were run.
- A commit was made with the change and the repository state reflects the single-file modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694df297ba14832b8ebbd3a357a5c48f)