### PR TITLE
Add themed Notebook and Tab styles and apply `Void.TNotebook`

### DIFF
--- a/void/gui.py
+++ b/void/gui.py
@@ -465,6 +465,30 @@ class VoidGUI:
             foreground=[("active", self.theme["accent_soft"])],
             relief=[("pressed", "sunken")],
         )
+        style.configure(
+            "Void.TNotebook",
+            background=self.theme["bg"],
+            borderwidth=0,
+            tabmargins=(2, 6, 2, 0),
+        )
+        style.configure(
+            "Void.TNotebook.Tab",
+            background=self.theme["panel_alt"],
+            foreground=self.theme["muted"],
+            padding=(14, 8),
+            font=("Consolas", 10, "bold"),
+        )
+        style.map(
+            "Void.TNotebook.Tab",
+            background=[
+                ("selected", self.theme["panel"]),
+                ("active", self.theme["button_active"]),
+            ],
+            foreground=[
+                ("selected", self.theme["accent"]),
+                ("active", self.theme["accent_soft"]),
+            ],
+        )
 
         header = tk.Canvas(
             self.root,
@@ -522,7 +546,7 @@ class VoidGUI:
         right = ttk.Frame(body, style="Void.TFrame")
         right.pack(side="left", fill="both", expand=True)
 
-        notebook = ttk.Notebook(right)
+        notebook = ttk.Notebook(right, style="Void.TNotebook")
         notebook.pack(fill="both", expand=True)
 
         dashboard = ttk.Frame(notebook, style="Void.TFrame")


### PR DESCRIPTION
### Motivation
- Make the main tabbed area follow the app theme so tabs visually match other UI surfaces.
- Provide clearer hover and selected states for notebook tabs to improve discoverability and contrast.

### Description
- Add `Void.TNotebook` style configured with `background`, `borderwidth`, and `tabmargins` to the existing `ttk.Style` setup in `_build_layout`.
- Add `Void.TNotebook.Tab` style with `background`, `foreground`, `padding`, and `font` to control tab appearance.
- Use `style.map` for `Void.TNotebook.Tab` to set different `background` and `foreground` for `selected` and `active` states.
- Apply the new style to the notebook instance by creating the widget with `ttk.Notebook(right, style="Void.TNotebook")`.

### Testing
- No automated tests were run for this change (visual/GUI styling update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e04bead0c832b8ed6b1e112feaaa2)