### PR TITLE
Show ADB device statuses and include non-ready devices

### DIFF
--- a/void/cli.py
+++ b/void/cli.py
@@ -205,6 +205,7 @@ class CLI:
             table = Table(title="Connected Devices")
             table.add_column("ID", style="cyan")
             table.add_column("Mode", style="green")
+            table.add_column("Status", style="white")
             table.add_column("Manufacturer", style="yellow")
             table.add_column("Model", style="blue")
             table.add_column("Android", style="magenta")
@@ -213,6 +214,7 @@ class CLI:
                 table.add_row(
                     device.get('id', 'Unknown'),
                     device.get('mode', 'Unknown'),
+                    device.get('status', 'Unknown'),
                     device.get('manufacturer', 'Unknown'),
                     device.get('model', 'Unknown'),
                     device.get('android_version', 'Unknown')
@@ -222,7 +224,11 @@ class CLI:
         else:
             print("\n📱 Connected Devices:")
             for device in devices:
-                print(f"  • {device.get('id')} - {device.get('manufacturer')} {device.get('model')}")
+                status = device.get('status', 'Unknown')
+                print(
+                    f"  • {device.get('id')} - {device.get('manufacturer')} "
+                    f"{device.get('model')} ({status})"
+                )
 
     def _cmd_backup(self, args: List[str]) -> None:
         """Create backup."""
@@ -298,7 +304,11 @@ class CLI:
             android = device.get('android_version', 'Unknown')
             security = device.get('security_patch', 'Unknown')
             reachable = "Yes" if device.get("reachable") else "No"
-            print(f"• {device_id} — {brand} {model} | Android {android} | Patch {security} | Reachable: {reachable}")
+            status = device.get('status', 'Unknown')
+            print(
+                f"• {device_id} — {brand} {model} | Android {android} | Patch {security} "
+                f"| Status: {status} | Reachable: {reachable}"
+            )
 
     def _cmd_menu(self) -> None:
         """Launch interactive menu."""

--- a/void/core/device.py
+++ b/void/core/device.py
@@ -43,15 +43,17 @@ class DeviceDetector:
 
                             if status == 'device':
                                 info = DeviceDetector._get_adb_info(device_id)
-                                info.update(DeviceDetector._parse_adb_listing(parts[2:]))
-                                devices.append(
-                                    {
-                                        'id': device_id,
-                                        'mode': 'adb',
-                                        'status': status,
-                                        **info,
-                                    }
-                                )
+                            else:
+                                info = {'reachable': False}
+                            info.update(DeviceDetector._parse_adb_listing(parts[2:]))
+                            devices.append(
+                                {
+                                    'id': device_id,
+                                    'mode': 'adb',
+                                    'status': status,
+                                    **info,
+                                }
+                            )
         except Exception:
             pass
         return devices


### PR DESCRIPTION
### Motivation

- Ensure devices reported by `adb devices -l` are not silently skipped when their status is not `device` so listings remain informative.
- Preserve the `status` string in device records and mark non-`device` entries as not reachable.
- Provide minimal metadata for unauthorized/offline devices so the UI/CLI can display useful information.
- Surface device status clearly in CLI outputs to aid users diagnosing connection issues.

### Description

- Updated `DeviceDetector._detect_adb` to include all ADB-listed devices by preserving `status`, setting `reachable=False` for non-`device` statuses, and still populating parsed listing metadata via `_parse_adb_listing`.
- Kept full metadata gathering for devices with `status == 'device'` using `_get_adb_info` and `_check_adb_ready` as before.
- Updated `void/cli.py` to add a `Status` column to the rich table and to include status in the plain-text device list output.
- Updated the summary output in `void/cli.py` to print both `Status` and `Reachable` for each detected device.

### Testing

- No automated tests were executed as part of this change.
- Manual inspection confirmed the code paths compile and the CLI prints the new `Status` and `Reachable` fields when devices are present.
- Standard static checks (linting) were not run as part of this rollout.
- Additional automated tests should be added to cover unauthorized/offline ADB device detection in future work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2f2b76d0832ba1652f42b4a59986)