### PR TITLE
Add USB VID/PID mappings and vendor hints for chipset detection

### DIFF
--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -104,6 +104,27 @@ def test_parse_adb_listing(tmp_path, monkeypatch):
     }
 
 
+def test_classify_usb_device_mapping(tmp_path, monkeypatch):
+    core = load_core(tmp_path, monkeypatch)
+
+    mapping = core.DeviceDetector._classify_usb_device("05c6", "9008")
+
+    assert mapping["mode"] == "edl"
+    assert mapping["usb_vendor"] == "Qualcomm"
+    assert mapping["chipset_vendor_hint"] == "Qualcomm"
+
+
+def test_classify_usb_device_fallback(tmp_path, monkeypatch):
+    core = load_core(tmp_path, monkeypatch)
+
+    mapping = core.DeviceDetector._classify_usb_device("05c6", "1234")
+
+    assert mapping["mode"] == "usb-unknown"
+    assert mapping["usb_vendor"] == "Qualcomm"
+
+    assert core.DeviceDetector._classify_usb_device("ffff", "0001") is None
+
+
 def test_check_adb_ready(tmp_path, monkeypatch):
     core = load_core(tmp_path, monkeypatch)
 

--- a/void/core/chipsets/mediatek.py
+++ b/void/core/chipsets/mediatek.py
@@ -43,6 +43,19 @@ class MediaTekChipset:
                     metadata={"usb_vid": vid, "usb_pid": pid},
                 )
 
+        if match_any(
+            context.get("usb_vendor") or context.get("chipset_vendor") or context.get("chipset_vendor_hint"),
+            ("mediatek", "mtk"),
+        ):
+            return ChipsetDetection(
+                chipset=self.name,
+                vendor=self.vendor,
+                mode=normalize_text(context.get("mode")) or "usb-unknown",
+                confidence=0.5,
+                notes=("Matched MediaTek USB vendor hint.",),
+                metadata={"usb_vendor": normalize_text(context.get("usb_vendor"))},
+            )
+
         for key in ("chipset", "hardware", "product", "device", "bootloader"):
             if match_any(context.get(key), self._PLATFORM_TOKENS):
                 return ChipsetDetection(

--- a/void/core/chipsets/qualcomm.py
+++ b/void/core/chipsets/qualcomm.py
@@ -33,6 +33,19 @@ class QualcommChipset:
                     metadata={"usb_vid": vid, "usb_pid": pid},
                 )
 
+        if match_any(
+            context.get("usb_vendor") or context.get("chipset_vendor") or context.get("chipset_vendor_hint"),
+            ("qualcomm", "qcom"),
+        ):
+            return ChipsetDetection(
+                chipset=self.name,
+                vendor=self.vendor,
+                mode=normalize_text(context.get("mode")) or "usb-unknown",
+                confidence=0.5,
+                notes=("Matched Qualcomm USB vendor hint.",),
+                metadata={"usb_vendor": normalize_text(context.get("usb_vendor"))},
+            )
+
         for key in ("chipset", "hardware", "product", "device", "bootloader"):
             if match_any(context.get(key), self._PLATFORM_TOKENS):
                 return ChipsetDetection(

--- a/void/core/chipsets/samsung.py
+++ b/void/core/chipsets/samsung.py
@@ -31,6 +31,19 @@ class SamsungExynosChipset:
                     metadata={"usb_vid": vid, "usb_pid": pid},
                 )
 
+        if match_any(
+            context.get("usb_vendor") or context.get("chipset_vendor") or context.get("chipset_vendor_hint"),
+            ("samsung",),
+        ):
+            return ChipsetDetection(
+                chipset=self.name,
+                vendor=self.vendor,
+                mode=normalize_text(context.get("mode")) or "usb-unknown",
+                confidence=0.5,
+                notes=("Matched Samsung USB vendor hint.",),
+                metadata={"usb_vendor": normalize_text(context.get("usb_vendor"))},
+            )
+
         for key in ("chipset", "hardware", "product", "device", "bootloader", "manufacturer"):
             if match_any(context.get(key), self._PLATFORM_TOKENS):
                 return ChipsetDetection(


### PR DESCRIPTION
### Motivation
- Replace fragile hardcoded VID/PID checks with a structured mapping to improve USB mode classification and vendor hints.
- Surface USB vendor hints in the detected device record so chipset detection has better context when PIDs are unknown.
- Allow chipset detectors to use vendor hints as a fallback to provide a best-effort `usb-unknown` mode.

### Description
- Introduce `_USB_VID_PID_MAP` and `_USB_VID_VENDOR_MAP` in `DeviceDetector` and replace `_classify_usb_mode` with `_classify_usb_device` returning a mapping dict with `mode`, `usb_vendor`, and `chipset_vendor_hint`.
- Populate `usb_vendor` and `chipset_vendor_hint` into the device record emitted by `_detect_usb_modes` and set `mode` to `usb-unknown` when VID is known but PID is not.
- Add vendor-hint detection branches to `Qualcomm`, `MediaTek`, and `SamsungExynos` chipset detectors to return a `ChipsetDetection` when `usb_vendor`/`chipset_vendor_hint` matches the vendor.
- Add unit tests `test_classify_usb_device_mapping` and `test_classify_usb_device_fallback` in `tests/test_core_helpers.py` to validate mapping and fallback behavior.

### Testing
- Ran the unit tests with `pytest tests/test_core_helpers.py`.
- All tests passed: `9 passed` (run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e2f2fdb88832bb120d83562f815ab)