### PR TITLE
Merge device detection records across modes and surface multi-mode info

### DIFF
--- a/void/cli.py
+++ b/void/cli.py
@@ -204,16 +204,18 @@ class CLI:
         if self.console:
             table = Table(title="Connected Devices")
             table.add_column("ID", style="cyan")
-            table.add_column("Mode", style="green")
+            table.add_column("Modes", style="green")
             table.add_column("Status", style="white")
             table.add_column("Manufacturer", style="yellow")
             table.add_column("Model", style="blue")
             table.add_column("Android", style="magenta")
 
             for device in devices:
+                modes = device.get("modes") or [device.get("mode", "Unknown")]
+                mode_label = ", ".join(modes) if isinstance(modes, list) else str(modes)
                 table.add_row(
                     device.get('id', 'Unknown'),
-                    device.get('mode', 'Unknown'),
+                    mode_label,
                     device.get('status', 'Unknown'),
                     device.get('manufacturer', 'Unknown'),
                     device.get('model', 'Unknown'),
@@ -225,9 +227,11 @@ class CLI:
             print("\n📱 Connected Devices:")
             for device in devices:
                 status = device.get('status', 'Unknown')
+                modes = device.get("modes") or [device.get("mode", "Unknown")]
+                mode_label = ", ".join(modes) if isinstance(modes, list) else str(modes)
                 print(
                     f"  • {device.get('id')} - {device.get('manufacturer')} "
-                    f"{device.get('model')} ({status})"
+                    f"{device.get('model')} ({status}) [{mode_label}]"
                 )
 
     def _cmd_backup(self, args: List[str]) -> None:
@@ -305,9 +309,11 @@ class CLI:
             security = device.get('security_patch', 'Unknown')
             reachable = "Yes" if device.get("reachable") else "No"
             status = device.get('status', 'Unknown')
+            modes = device.get("modes") or [device.get("mode", "Unknown")]
+            mode_label = ", ".join(modes) if isinstance(modes, list) else str(modes)
             print(
                 f"• {device_id} — {brand} {model} | Android {android} | Patch {security} "
-                f"| Status: {status} | Reachable: {reachable}"
+                f"| Status: {status} | Modes: {mode_label} | Reachable: {reachable}"
             )
 
     def _cmd_menu(self) -> None:

--- a/void/gui.py
+++ b/void/gui.py
@@ -987,6 +987,8 @@ class VoidGUI:
         battery = info.get("battery", {})
         storage = info.get("storage", {})
         mode = info.get("mode", "Unknown")
+        modes = info.get("modes") or [mode]
+        mode_label = ", ".join(modes) if isinstance(modes, list) else str(modes)
         chipset = info.get("chipset", "Unknown")
         chipset_vendor = info.get("chipset_vendor", "Unknown")
         chipset_mode = info.get("chipset_mode", "Unknown")
@@ -996,12 +998,15 @@ class VoidGUI:
         usb_vid = info.get("usb_vid", "Unknown")
         usb_pid = info.get("usb_pid", "Unknown")
         status = info.get("status", "Unknown")
+        statuses = info.get("statuses") or [status]
+        status_label = ", ".join(statuses) if isinstance(statuses, list) else str(statuses)
         reachable = "Yes" if info.get("reachable", False) else "No"
         self.selected_device_var.set(f"{device_id} • {manufacturer} {model}")
         self.details_var.set(
             "Device Overview\n"
             f"• Mode: {mode} | Reachable: {reachable}\n"
-            f"• Status: {status}\n"
+            f"• Modes: {mode_label}\n"
+            f"• Status: {status} | Statuses: {status_label}\n"
             f"• Brand: {brand} | Product: {product}\n"
             f"• Android: {android} (SDK {sdk})\n"
             f"• Build: {build_id} ({build_type})\n"
@@ -1045,8 +1050,10 @@ class VoidGUI:
         for device in devices:
             device_id = device.get("id", "unknown")
             reachable = "✓" if device.get("reachable") else "!"
+            modes = device.get("modes") or [device.get("mode", "Unknown")]
+            mode_label = ", ".join(modes) if isinstance(modes, list) else str(modes)
             label = (
-                f"{reachable} {device_id} • "
+                f"{reachable} {device_id} • {mode_label} • "
                 f"{device.get('manufacturer', 'Unknown')} {device.get('model', '')}"
             )
             self.device_list.insert(tk.END, label.strip())


### PR DESCRIPTION
### Motivation
- Devices detected via ADB, fastboot, and raw USB could produce separate records for the same physical device, causing duplication and loss of richer context.  
- Provide a stable grouping key (serial/id/USB id) so records from multiple sources can be combined.  
- Preserve a single `mode` for backwards compatibility while exposing `modes` and `statuses` lists for richer output.  
- Ensure UI/CLI prefer merged records to present a clearer, consolidated device view.

### Description
- Added a merge step to `DeviceDetector.detect_all()` that calls a new helper `DeviceDetector._merge_devices()` to group and combine records.  
- Introduced helper functions `DeviceDetector._device_merge_key()`, `DeviceDetector._device_priority()`, and `DeviceDetector._dedupe_list()` to pick stable grouping keys and enforce precedence (`adb` > `fastboot` > `usb`).  
- Merge logic preserves the best value for existing fields, sets `mode` to the highest-priority source, and exposes `modes` and `statuses` lists on merged records.  
- Updated UI (`void/gui.py`) to prefer merged records and display `modes` and `statuses` in the device list and detail panel, and updated CLI (`void/cli.py`) to show a `Modes` column and include modes in textual listings and summaries.

### Testing
- No automated tests were executed as part of this change.  
- Existing behavior should be preserved for callers that rely on the single `mode` field since `mode` is still set to the highest-priority source.  
- Manual verification recommended for multi-source scenarios (ADB + fastboot + USB) to confirm merged representations are correct.  
- If desired, add unit tests for `_merge_devices()` to cover grouping and precedence rules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e314a90d0832bbb6320c72cb65037)