### PR TITLE
Improve device detection and add force USB debugging CLI

### DIFF
--- a/tests/test_core_helpers.py
+++ b/tests/test_core_helpers.py
@@ -93,7 +93,7 @@ def test_parse_adb_listing(tmp_path, monkeypatch):
     core = load_core(tmp_path, monkeypatch)
 
     info = core.DeviceDetector._parse_adb_listing(
-        ["product:sailfish", "model:Pixel", "device:marlin", "transport_id:1"]
+        ["product:sailfish", "model:Pixel", "device:marlin", "transport_id:1", "usb:1-1"]
     )
 
     assert info == {
@@ -101,6 +101,7 @@ def test_parse_adb_listing(tmp_path, monkeypatch):
         "model": "Pixel",
         "device": "marlin",
         "transport_id": "1",
+        "usb_path": "1-1",
     }
 
 


### PR DESCRIPTION
### Motivation
- Improve metadata collected from connected devices to make detection more reliable across ADB, fastboot and low-level USB modes.
- Provide a practical way to enable or force USB debugging on engineering/firmware devices where the normal setting may be disabled.
- Surface helpful information (USB path/product and serial normalization) to drive chipset detection and tooling workflows.

### Description
- Parse `usb:` entries from `adb devices -l` into `usb_path` and capture `usb_product` from `lsusb` output to enrich USB device records.
- Ensure ADB detection includes a `serial` field by default and include `serial` for fastboot devices, and prefer `serialno` from `fastboot getvar` when available.
- Add `SystemTweaker.force_usb_debugging` which runs multiple ADB steps (settings, `setprop`, and adbd restart) and reports per-step results.
- Expose a new CLI command `usb-debug <device_id> [force]` and update help/examples accordingly, plus a unit test adjustment for parsing the `usb` field.

### Testing
- Ran the test suite with `pytest -q`, producing `16 passed` and no failures.
- Unit test updated: `test_parse_adb_listing` now validates the `usb_path` extraction from adb output using `usb:...` input.
- No integration/system tests were run as part of this change (only the automated unit tests above).
- Manual smoke checks for CLI help and examples were updated in the help text (non-automated verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e325f5db4832ba5e0e80959cddbf9)