### PR TITLE
Emit progress callbacks for backup/report/logcat and extend GUI task runner

### DIFF
--- a/void/core/logcat.py
+++ b/void/core/logcat.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import subprocess
-from typing import Optional
+from typing import Callable, Optional
 
 from .logging import logger
 
@@ -13,8 +13,15 @@ class LogcatViewer:
         self.process = None
         self.running = False
 
-    def start(self, device_id: str, filter_tag: str = None):
+    def start(
+        self,
+        device_id: str,
+        filter_tag: str = None,
+        progress_callback: Optional[Callable[[str], None]] = None,
+    ):
         """Start logcat"""
+        if progress_callback:
+            progress_callback("Starting logcat stream...")
         cmd = ['adb', '-s', device_id, 'logcat']
         if filter_tag:
             cmd.extend(['-s', filter_tag])
@@ -28,13 +35,17 @@ class LogcatViewer:
         )
 
         logger.log('info', 'logcat', 'Logcat started')
+        if progress_callback:
+            progress_callback("Logcat streaming.")
 
-    def stop(self):
+    def stop(self, progress_callback: Optional[Callable[[str], None]] = None):
         """Stop logcat"""
         if self.process:
             self.process.terminate()
             self.running = False
             logger.log('info', 'logcat', 'Logcat stopped')
+            if progress_callback:
+                progress_callback("Logcat stopped.")
 
     def read_line(self) -> Optional[str]:
         """Read one line"""


### PR DESCRIPTION
### Motivation
- Surface progress updates for long-running operations (backup, report generation, and logcat) to improve user feedback and logs.

### Description
- Extend `_run_task` to accept an optional `progress_callback` and emit progress messages into the GUI `progress_var` and the provided callback.
- Update `AutoBackup.create_backup` and `ReportGenerator.generate_device_report` to accept `progress_callback` and emit human-friendly statuses such as `Collecting device info...`, `Pulling build.prop...`, `Rendering report...`, and `Backup complete.`.
- Add optional `progress_callback` parameters to `LogcatViewer.start` and `LogcatViewer.stop` to surface `Starting logcat stream...` and `Logcat stopped.` messages.
- Wire GUI backup and report actions to pass `progress_callback=self._log` so progress updates appear in the operations log and the status label via `progress_var`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e513c3520832b853f2f403367c173)