### PR TITLE
Capture device detection errors and surface diagnostics in GUI

### DIFF
--- a/void/cli.py
+++ b/void/cli.py
@@ -196,7 +196,7 @@ class CLI:
 
     def _cmd_devices(self) -> None:
         """List devices."""
-        devices = DeviceDetector.detect_all()
+        devices, _ = DeviceDetector.detect_all()
 
         if not devices:
             print("❌ No devices detected")
@@ -283,7 +283,7 @@ class CLI:
             print("Usage: info <device_id>")
             return
 
-        devices = DeviceDetector.detect_all()
+        devices, _ = DeviceDetector.detect_all()
         device = next((d for d in devices if d['id'] == args[0]), None)
 
         if device:
@@ -296,7 +296,7 @@ class CLI:
 
     def _cmd_summary(self) -> None:
         """Show a short device summary."""
-        devices = DeviceDetector.detect_all()
+        devices, _ = DeviceDetector.detect_all()
         if not devices:
             print("❌ No devices detected")
             return
@@ -703,7 +703,7 @@ class CLI:
 
     def _cmd_devices_json(self) -> None:
         """Export connected devices to JSON."""
-        devices = DeviceDetector.detect_all()
+        devices, _ = DeviceDetector.detect_all()
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         export_path = Config.EXPORTS_DIR / f"devices_{timestamp}.json"
         export_path.write_text(json.dumps(devices, indent=2))
@@ -1371,7 +1371,7 @@ class CLI:
             print("❌ Unknown operation")
 
     def _resolve_device_context(self, device_id: str) -> tuple[dict[str, str], Dict[str, Any] | None]:
-        devices = DeviceDetector.detect_all()
+        devices, _ = DeviceDetector.detect_all()
         device = None
         for item in devices:
             if item.get("id") == device_id:

--- a/void/core/backup.py
+++ b/void/core/backup.py
@@ -37,7 +37,7 @@ class AutoBackup:
 
         # Backup device info
         info_file = backup_path / "device_info.json"
-        devices = DeviceDetector.detect_all()
+        devices, _ = DeviceDetector.detect_all()
         device_info = next((d for d in devices if d['id'] == device_id), {})
         with open(info_file, 'w') as f:
             json.dump(device_info, f, indent=2, default=str)

--- a/void/core/report.py
+++ b/void/core/report.py
@@ -37,7 +37,7 @@ class ReportGenerator:
         # Device info
         if progress_callback:
             progress_callback("Collecting device info...")
-        devices = DeviceDetector.detect_all()
+        devices, _ = DeviceDetector.detect_all()
         device_info = next((d for d in devices if d['id'] == device_id), {})
         report['sections']['device_info'] = device_info
 

--- a/void/main.py
+++ b/void/main.py
@@ -67,7 +67,7 @@ def main() -> None:
         return
 
     if args.devices:
-        devices = DeviceDetector.detect_all()
+    devices, _ = DeviceDetector.detect_all()
         logger.info(
             "Connected Devices:",
             extra={"category": "devices", "device_id": "-", "method": "-"},


### PR DESCRIPTION
### Motivation
- Surface and record errors from external detection tools (adb/fastboot/lsusb) so diagnostics can guide users when tooling or permissions fail.
- Avoid swallowing subprocess failures and provide both developer logs and user-friendly hints in the GUI.
- Keep existing callers working while returning structured error information for troubleshooting.

### Description
- Change `DeviceDetector.detect_all` to return `Tuple[List[Dict], List[Dict]]` as `(devices, errors)` and propagate this signature through callers like `cli`, `main`, `report`, and `backup` by unpacking the tuple with `devices, _`.
- Implement structured detection errors via a new helper `DeviceDetector._build_detection_error` which records `source`, `code`, `message`, and `details` (`command`, `exit_code`, `stdout`, `stderr`).
- Update detection functions `DeviceDetector._detect_adb`, `_detect_fastboot`, and `_detect_usb_modes` to return `(devices, errors)` and append structured errors when subprocess commands fail.
- In the GUI, store errors in `self.detection_errors`, log full error payloads with `self._log(..., level="ERROR")`, and set a user-friendly diagnostics hint in `status_var` using `_summarize_detection_errors` while directing users to Troubleshooting → Diagnostics.

### Testing
- No automated tests were executed as part of this change.
- Manual verification steps were not included in the automated rollout notes.
- Existing call sites were updated to unpack the new `detect_all` return value to preserve behaviour when errors are present.
- The change was committed and packaged as a single change that updates device detection and GUI diagnostics handling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e53533560832baaccae28af80ae26)