### PR TITLE
Add persistent GUI Settings tab and persist config for backups/reports/analytics

### DIFF
--- a/void/config.py
+++ b/void/config.py
@@ -8,6 +8,9 @@ Unauthorized copying, modification, distribution, or disclosure is prohibited.
 """
 
 from pathlib import Path
+from typing import Any, Dict
+
+import json
 
 
 class Config:
@@ -53,6 +56,7 @@ class Config:
 
     # Paths
     BASE_DIR = Path.home() / ".void"
+    CONFIG_PATH = BASE_DIR / "config.json"
     DB_PATH = BASE_DIR / "void.db"
     LOG_DIR = BASE_DIR / "logs"
     BACKUP_DIR = BASE_DIR / "backups"
@@ -67,15 +71,31 @@ class Config:
 
     # Features
     ENABLE_AUTO_BACKUP = True
+    ENABLE_REPORTS = True
     ENABLE_MONITORING = True
     ENABLE_ANALYTICS = True
 
     # Crypto
     ALLOW_INSECURE_CRYPTO = False
 
+    DEFAULT_SETTINGS: Dict[str, Any] = {
+        "enable_auto_backup": ENABLE_AUTO_BACKUP,
+        "enable_reports": ENABLE_REPORTS,
+        "enable_analytics": ENABLE_ANALYTICS,
+        "exports_dir": str(EXPORTS_DIR),
+        "reports_dir": str(REPORTS_DIR),
+    }
+
     @classmethod
     def setup(cls) -> None:
         """Create necessary directories."""
+        cls.BASE_DIR.mkdir(parents=True, exist_ok=True)
+        cls.load_settings()
+        cls.ensure_directories()
+
+    @classmethod
+    def ensure_directories(cls) -> None:
+        """Ensure configured directories exist."""
         for path in [
             cls.BASE_DIR,
             cls.LOG_DIR,
@@ -86,6 +106,71 @@ class Config:
             cls.MONITOR_DIR,
             cls.SCRIPTS_DIR,
         ]:
-            if path.exists():
-                continue
             path.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def read_config(cls) -> Dict[str, Any]:
+        """Read the JSON config file."""
+        try:
+            with cls.CONFIG_PATH.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+                return data if isinstance(data, dict) else {}
+        except FileNotFoundError:
+            return {}
+        except json.JSONDecodeError:
+            return {}
+
+    @classmethod
+    def write_config(cls, data: Dict[str, Any]) -> None:
+        """Persist JSON config data."""
+        cls.BASE_DIR.mkdir(parents=True, exist_ok=True)
+        with cls.CONFIG_PATH.open("w", encoding="utf-8") as handle:
+            json.dump(data, handle, indent=2, sort_keys=True)
+
+    @classmethod
+    def _normalize_settings(cls, settings: Dict[str, Any]) -> Dict[str, Any]:
+        merged = {**cls.DEFAULT_SETTINGS, **(settings or {})}
+
+        def _parse_dir(value: Any, fallback: Path) -> Path:
+            if not value:
+                return fallback
+            try:
+                return Path(value).expanduser()
+            except (TypeError, ValueError):
+                return fallback
+
+        exports_dir = _parse_dir(merged.get("exports_dir"), cls.EXPORTS_DIR)
+        reports_dir = _parse_dir(merged.get("reports_dir"), cls.REPORTS_DIR)
+
+        normalized = {
+            "enable_auto_backup": bool(merged.get("enable_auto_backup")),
+            "enable_reports": bool(merged.get("enable_reports")),
+            "enable_analytics": bool(merged.get("enable_analytics")),
+            "exports_dir": str(exports_dir),
+            "reports_dir": str(reports_dir),
+        }
+
+        cls.ENABLE_AUTO_BACKUP = normalized["enable_auto_backup"]
+        cls.ENABLE_REPORTS = normalized["enable_reports"]
+        cls.ENABLE_ANALYTICS = normalized["enable_analytics"]
+        cls.EXPORTS_DIR = exports_dir
+        cls.REPORTS_DIR = reports_dir
+
+        return normalized
+
+    @classmethod
+    def load_settings(cls) -> Dict[str, Any]:
+        """Load settings from the config file and apply them."""
+        data = cls.read_config()
+        settings = data.get("settings", {}) if isinstance(data, dict) else {}
+        return cls._normalize_settings(settings)
+
+    @classmethod
+    def save_settings(cls, settings: Dict[str, Any]) -> Dict[str, Any]:
+        """Save settings to the config file."""
+        normalized = cls._normalize_settings(settings)
+        data = cls.read_config()
+        data["settings"] = normalized
+        cls.write_config(data)
+        cls.ensure_directories()
+        return normalized


### PR DESCRIPTION
### Motivation
- Provide a user-facing Settings panel to control backups, reports, analytics toggles, and export/report folders from the GUI.
- Persist user preferences so GUI behavior and export/report locations survive restarts.
- Centralize reading/writing of a JSON config file under `Config.BASE_DIR` for settings management.
- Ensure directories configured in settings are created automatically at startup.

### Description
- Added `Config.CONFIG_PATH`, `DEFAULT_SETTINGS` and helpers `read_config`, `write_config`, `_normalize_settings`, `load_settings`, and `save_settings` to `void/config.py` to persist and apply settings from `config.json`.
- Updated `Config.setup()` to call `load_settings()` and `ensure_directories()` so configured directories are created and feature flags are applied at startup.
- Extended GUI (`void/gui.py`) to add a `Settings` tab with checkboxes for `Enable backups`, `Enable reports`, and `Enable analytics`, and directory pickers for `Exports` and `Reports` folders, backed by `tk.BooleanVar`/`tk.StringVar` state.
- Wired GUI actions to respect persisted flags (disable/show warnings for backups/reports/analyze when disabled), added `Save Settings` to persist to `config.json`, and added `_sync_action_buttons()` to update action button states.

### Testing
- No automated tests were run as part of this change set.
- Manual verification expected: GUI shows new `Settings` tab, toggles persist to `config.json`, and action buttons enable/disable according to saved settings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e544438a4832b89d14e1bb0a1d4f0)