### PR TITLE
Fix indentation in devices handling to resolve IndentationError

### DIFF
--- a/void/main.py
+++ b/void/main.py
@@ -67,7 +67,7 @@ def main() -> None:
         return
 
     if args.devices:
-    devices, _ = DeviceDetector.detect_all()
+        devices, _ = DeviceDetector.detect_all()
         logger.info(
             "Connected Devices:",
             extra={"category": "devices", "device_id": "-", "method": "-"},


### PR DESCRIPTION
### Motivation
- Running the CLI crashed with an `IndentationError` in the `--devices` path which prevented listing connected devices.
- The code change ensures the device detection logic under `args.devices` executes as intended.

### Description
- Corrected the indentation of `devices, _ = DeviceDetector.detect_all()` inside the `if args.devices:` block in `void/main.py`.
- The change is limited to fixing block indentation and does not alter program logic or other code paths.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e5ab6807c832b84408f0c67a4cc3c)