### PR TITLE
Fix GUI theme border and log buffering

### DIFF
--- a/void/config.py
+++ b/void/config.py
@@ -41,6 +41,7 @@ class Config:
         "button_bg": "#0f1826",
         "button_active": "#1b2a3d",
         "button_text": "#00f5d4",
+        "border": "#1b2a3d",
         "gradient_start": "#0a1220",
         "gradient_end": "#16243b",
         "splash_start": "#04060b",


### PR DESCRIPTION
### Motivation
- Prevent a startup `KeyError` when the GUI reads a missing `"border"` color from the theme.
- Avoid `AttributeError` / lost log entries when background tasks emit log messages before the log widget is created.

### Description
- Add the missing `"border"` color to `Config.GUI_THEME` in `void/config.py` to satisfy UI lookups.
- Initialize `self.output` and a `self._pending_log_entries` buffer in `VoidGUI` and drain the buffer when the log widget is built in `void/gui.py`.
- Update `_log` to append entries to the pending buffer if `self.output` is not yet available and to use a preformatted `entry` string when inserting.
- Guard `_export_log` with a check that shows a warning if the log widget is not available yet.

### Testing
- No automated tests were executed for this change.
- (No test failures reported because automated test run was not requested.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e5c2fc98c832bae5906e71d597aee)