### PR TITLE
Add display diagnostics analyzer and surface results in GUI/CLI/reports

### DIFF
--- a/void/cli.py
+++ b/void/cli.py
@@ -26,6 +26,7 @@ from .core.backup import AutoBackup
 from .core.data_recovery import DataRecovery
 from .core.database import db
 from .core.device import DeviceDetector
+from .core.display import DisplayAnalyzer
 from .core.edl import edl_dump, edl_flash
 from .core.files import FileManager
 from .core.frp import FRPEngine
@@ -96,6 +97,7 @@ class CLI:
                     'apps': lambda: self._cmd_apps(args),
                     'files': lambda: self._cmd_files(args),
                     'analyze': lambda: self._cmd_analyze(args),
+                    'display-diagnostics': lambda: self._cmd_display_diagnostics(args),
                     'recover': lambda: self._cmd_recover(args),
                     'tweak': lambda: self._cmd_tweak(args),
                     'usb-debug': lambda: self._cmd_usb_debug(args),
@@ -276,6 +278,15 @@ class CLI:
 
         if len(apps) > 20:
             print(f"  ... and {len(apps) - 20} more")
+
+    def _cmd_display_diagnostics(self, args: List[str]) -> None:
+        """Run display diagnostics."""
+        if len(args) < 1:
+            print("Usage: display-diagnostics <device_id>")
+            return
+
+        diagnostics = DisplayAnalyzer.analyze(args[0])
+        print(json.dumps(diagnostics, indent=2))
 
     def _cmd_info(self, args: List[str]) -> None:
         """Show device info."""
@@ -1618,6 +1629,7 @@ FILE OPERATIONS:
   
 ANALYSIS:
   analyze <device_id>              - Performance analysis
+  display-diagnostics <device_id>  - Display + framebuffer diagnostics
   report <device_id>               - Generate full report
   logcat <device_id> [tag]         - View real-time logs
   
@@ -1691,6 +1703,7 @@ SYSTEM:
   void> screenshot emulator-5554
   void> apps emulator-5554 user
   void> analyze emulator-5554
+  void> display-diagnostics emulator-5554
   void> recover emulator-5554 contacts
   void> tweak emulator-5554 dpi 320
   void> usb-debug emulator-5554 force

--- a/void/core/__init__.py
+++ b/void/core/__init__.py
@@ -16,6 +16,7 @@ from .authorized_device_auditor import AuthorizedDeviceAuditor
 from .backup import AutoBackup
 from .data_recovery import DataRecovery
 from .database import Database, db
+from .display import DisplayAnalyzer
 from .device import DeviceDetector
 from .firmware_integrity import (
     dump_partition_via_adb,
@@ -46,6 +47,7 @@ __all__ = [
     'AutoBackup',
     'DataRecovery',
     'Database',
+    'DisplayAnalyzer',
     'DeviceDetector',
     'dump_partition_via_adb',
     'enable_debugging_settings',

--- a/void/core/display.py
+++ b/void/core/display.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import re
+from typing import Any, Dict, Optional
+
+from .screen import ScreenCapture
+from .utils import SafeSubprocess
+
+
+def _parse_screen_state(power_output: str) -> tuple[Optional[str], Optional[str]]:
+    screen_state = None
+    display_power = None
+
+    for line in power_output.splitlines():
+        stripped = line.strip()
+        if "Display Power" in stripped and "state=" in stripped:
+            display_power = stripped.split("Display Power:", 1)[-1].strip()
+            state_match = re.search(r"state=([A-Za-z]+)", stripped)
+            if state_match:
+                state = state_match.group(1).lower()
+                screen_state = "on" if state == "on" else "off" if state == "off" else state
+        elif "mScreenOn=" in stripped:
+            value = stripped.split("mScreenOn=", 1)[-1].split()[0].strip().lower()
+            screen_state = "on" if value == "true" else "off" if value == "false" else value
+        elif "mWakefulness=" in stripped and screen_state is None:
+            value = stripped.split("mWakefulness=", 1)[-1].split()[0].strip().lower()
+            if value in {"awake", "dreaming"}:
+                screen_state = "on"
+            elif value in {"asleep", "dozing"}:
+                screen_state = "off"
+
+    return screen_state, display_power
+
+
+def _parse_display_info(display_output: str) -> tuple[Optional[str], Optional[str]]:
+    brightness = None
+    refresh_rate = None
+
+    for line in display_output.splitlines():
+        stripped = line.strip()
+        if brightness is None:
+            brightness_match = re.search(r"brightness=([0-9.]+)", stripped)
+            if brightness_match:
+                brightness = brightness_match.group(1)
+            elif any(key in stripped for key in ("mScreenBrightnessSetting", "mScreenBrightness", "mBrightness")):
+                if "=" in stripped:
+                    brightness = stripped.split("=", 1)[-1].strip()
+                elif ":" in stripped:
+                    brightness = stripped.split(":", 1)[-1].strip()
+        if refresh_rate is None:
+            refresh_match = re.search(r"refreshRate=([0-9.]+)", stripped)
+            if refresh_match:
+                refresh_rate = refresh_match.group(1)
+            elif "mRefreshRate" in stripped:
+                if "=" in stripped:
+                    refresh_rate = stripped.split("=", 1)[-1].strip()
+                elif ":" in stripped:
+                    refresh_rate = stripped.split(":", 1)[-1].strip()
+        if brightness is not None and refresh_rate is not None:
+            break
+
+    return brightness, refresh_rate
+
+
+def _pillow_available() -> bool:
+    return importlib.util.find_spec("PIL") is not None
+
+
+class DisplayAnalyzer:
+    """Display and framebuffer diagnostics."""
+
+    @staticmethod
+    def analyze(device_id: str) -> Dict[str, Any]:
+        analysis: Dict[str, Any] = {
+            "screen_state": None,
+            "display_power": None,
+            "display_brightness": None,
+            "refresh_rate": None,
+            "surfaceflinger_ok": None,
+            "surfaceflinger_source": None,
+            "black_frame_detected": None,
+            "screenshot_path": None,
+            "screenshot_analysis": None,
+        }
+
+        code, power_out, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "dumpsys", "power"]
+        )
+        if code == 0:
+            screen_state, display_power = _parse_screen_state(power_out)
+            analysis["screen_state"] = screen_state
+            analysis["display_power"] = display_power
+
+        code, display_out, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "dumpsys", "display"]
+        )
+        if code == 0:
+            brightness, refresh_rate = _parse_display_info(display_out)
+            analysis["display_brightness"] = brightness
+            analysis["refresh_rate"] = refresh_rate
+
+        code, surface_out, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "dumpsys", "SurfaceFlinger"]
+        )
+        source = "SurfaceFlinger"
+        if code != 0 or not surface_out.strip():
+            code, surface_out, _ = SafeSubprocess.run(
+                ["adb", "-s", device_id, "shell", "dumpsys", "gfxinfo"]
+            )
+            source = "gfxinfo"
+        analysis["surfaceflinger_ok"] = code == 0 and bool(surface_out.strip())
+        analysis["surfaceflinger_source"] = source
+
+        screenshot = ScreenCapture.take_screenshot(device_id)
+        if screenshot.get("success"):
+            analysis["screenshot_path"] = screenshot.get("path")
+            if _pillow_available():
+                image_module = importlib.import_module("PIL.Image")
+                stat_module = importlib.import_module("PIL.ImageStat")
+                with image_module.open(screenshot["path"]) as img:
+                    rgb = img.convert("RGB")
+                    stats = stat_module.Stat(rgb)
+                mean = stats.mean
+                avg = sum(mean) / 3 if mean else 0
+                threshold = 10
+                analysis["black_frame_detected"] = avg < threshold
+                analysis["screenshot_analysis"] = {
+                    "average_rgb": [round(channel, 2) for channel in mean],
+                    "average_luminance": round(avg, 2),
+                    "threshold": threshold,
+                }
+            else:
+                analysis["screenshot_analysis"] = {
+                    "note": "Pillow not installed; screenshot captured without pixel analysis.",
+                }
+        else:
+            analysis["screenshot_analysis"] = {
+                "error": screenshot.get("error", "Screenshot failed."),
+            }
+
+        return analysis

--- a/void/core/report.py
+++ b/void/core/report.py
@@ -9,6 +9,7 @@ from ..config import Config
 from .apps import AppManager
 from .database import db
 from .device import DeviceDetector
+from .display import DisplayAnalyzer
 from .logging import logger
 from .network import NetworkAnalyzer
 from .performance import PerformanceAnalyzer
@@ -50,6 +51,11 @@ class ReportGenerator:
         if progress_callback:
             progress_callback("Analyzing network...")
         report['sections']['network'] = NetworkAnalyzer.analyze(device_id)
+
+        # Display diagnostics
+        if progress_callback:
+            progress_callback("Analyzing display...")
+        report['sections']['display'] = DisplayAnalyzer.analyze(device_id)
 
         # App list
         if progress_callback:
@@ -166,6 +172,21 @@ class ReportGenerator:
                     label = key.replace('_', ' ').title()
                     html += f"<tr><td><strong>{label}</strong></td><td>{value}</td></tr>"
 
+            html += """            </table>
+        </div>
+"""
+
+        # Display diagnostics
+        if 'display' in report['sections']:
+            display = report['sections']['display']
+            html += """        <div class=\"section\">
+            <h2>Display Diagnostics</h2>
+            <table>
+"""
+            for key, value in display.items():
+                if not isinstance(value, (dict, list)):
+                    label = key.replace('_', ' ').title()
+                    html += f"<tr><td><strong>{label}</strong></td><td>{value}</td></tr>"
             html += """            </table>
         </div>
 """

--- a/void/gui.py
+++ b/void/gui.py
@@ -27,6 +27,7 @@ from .core.chipsets.dispatcher import (
     recover_chipset_device,
 )
 from .core.device import DeviceDetector
+from .core.display import DisplayAnalyzer
 from .core.performance import PerformanceAnalyzer
 from .core.report import ReportGenerator
 from .core.screen import ScreenCapture
@@ -406,6 +407,41 @@ class VoidGUI:
                 "links": driver_status.get("links", []),
             }
         )
+
+        if self.selected_device_id:
+            display = DisplayAnalyzer.analyze(self.selected_device_id)
+            status = "pass"
+            if display.get("surfaceflinger_ok") is False:
+                status = "fail"
+            elif display.get("black_frame_detected"):
+                status = "warn"
+            elif not display.get("screen_state"):
+                status = "warn"
+
+            detail_parts = [
+                f"screen={display.get('screen_state') or 'unknown'}",
+                f"power={display.get('display_power') or 'n/a'}",
+                f"brightness={display.get('display_brightness') or 'n/a'}",
+                f"refresh={display.get('refresh_rate') or 'n/a'}",
+                f"black_frame={display.get('black_frame_detected')}",
+            ]
+            items.append(
+                {
+                    "label": "Display state / framebuffer",
+                    "status": status,
+                    "detail": ", ".join(detail_parts),
+                    "links": [],
+                }
+            )
+        else:
+            items.append(
+                {
+                    "label": "Display state / framebuffer",
+                    "status": "warn",
+                    "detail": "Select a device to analyze display diagnostics.",
+                    "links": [],
+                }
+            )
         return items
 
     def _update_diagnostics(self) -> None:


### PR DESCRIPTION
### Motivation

- Add a display-focused analyzer to detect display/power state, compositor health, and potential black frames from device framebuffer captures.
- Surface this information to users through the GUI diagnostics checklist, generated device reports, and a headless CLI command for troubleshooting.
- Provide structured, machine-readable fields so downstream tools and reports can consume display diagnostics reliably.

### Description

- Add `void/core/display.py` implementing `DisplayAnalyzer.analyze(device_id)` which runs `adb shell dumpsys power`, `adb shell dumpsys display`, and `adb shell dumpsys SurfaceFlinger`/`gfxinfo`, and returns structured fields like `screen_state`, `display_power`, `display_brightness`, `refresh_rate`, `surfaceflinger_ok`, `black_frame_detected`, and `screenshot_path`.
- Use the existing `ScreenCapture.take_screenshot` and perform optional pixel analysis with Pillow when available to detect near-black frames, otherwise record that a screenshot was captured without pixel analysis.
- Export `DisplayAnalyzer` from `void/core/__init__.py`, add display diagnostics into report generation in `void/core/report.py` and render a `Display Diagnostics` section in the HTML report.
- Integrate the analyzer into the GUI diagnostics list in `void/gui.py` as a new item `Display state / framebuffer`, and add a CLI command `display-diagnostics <device_id>` in `void/cli.py` which prints the JSON diagnostics.

### Testing

- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ec9bf991c832b96e116c78ef2be52)