### PR TITLE
Add CLI command suggestions

### DIFF
--- a/void/cli.py
+++ b/void/cli.py
@@ -10,6 +10,7 @@ Unauthorized copying, modification, distribution, or disclosure is prohibited.
 from __future__ import annotations
 
 import csv
+import difflib
 import json
 import platform
 import shutil
@@ -157,10 +158,13 @@ class CLI:
                 if command in commands:
                     commands[command]()
                 else:
+                    suggestions = self._suggest_commands(command, list(commands.keys()))
                     self.logger.warning(
                         f"Unknown command: {command}",
                         extra={"category": "cli", "device_id": "-", "method": "-"},
                     )
+                    if suggestions:
+                        print(f"Did you mean: {', '.join(suggestions)}?")
 
             except KeyboardInterrupt:
                 self.logger.info(
@@ -172,6 +176,17 @@ class CLI:
                     f"Error: {exc}",
                     extra={"category": "cli", "device_id": "-", "method": "-"},
                 )
+
+    def _suggest_commands(self, command: str, options: List[str]) -> List[str]:
+        """Suggest similar commands for typos or partial input."""
+        if not command:
+            return []
+
+        prefix_matches = [option for option in options if option.startswith(command)]
+        if prefix_matches:
+            return sorted(prefix_matches)[:5]
+
+        return difflib.get_close_matches(command, options, n=5, cutoff=0.5)
 
     def _print_banner(self) -> None:
         """Print banner."""


### PR DESCRIPTION
### Motivation
- Improve CLI usability by helping users recover from typos or partial commands.
- Provide quick feedback and reduce friction when users enter unknown commands.

### Description
- Import `difflib` and add a new `_suggest_commands` helper that returns prefix matches or fuzzy matches via `difflib.get_close_matches` (max 5 results, cutoff 0.5).
- Invoke `_suggest_commands` in the main command dispatch path and print suggestions when an unknown command is entered while still logging the warning.
- Keep existing logging behavior and preserve the existing commands mapping and flow.

### Testing
- No automated tests were executed for this change.
- The change is limited to CLI UX behavior and does not alter existing command implementations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694eb383edf8832b9b55e7cd66a393eb)