### PR TITLE
Ensure GUI appears before Terms prompt and parent dialog to root

### DIFF
--- a/void/gui.py
+++ b/void/gui.py
@@ -377,7 +377,9 @@ class VoidGUI:
         if self._splash_window:
             self._splash_window.destroy()
         self._build_layout()
-        if not ensure_terms_acceptance_gui(messagebox):
+        self.root.deiconify()
+        self.root.update_idletasks()
+        if not ensure_terms_acceptance_gui(messagebox, parent=self.root):
             self.root.destroy()
             raise SystemExit(0)
         if not self._is_first_run_complete():

--- a/void/terms.py
+++ b/void/terms.py
@@ -57,7 +57,7 @@ def ensure_terms_acceptance_cli() -> bool:
     return True
 
 
-def ensure_terms_acceptance_gui(messagebox) -> bool:
+def ensure_terms_acceptance_gui(messagebox, parent=None) -> bool:
     """Require acceptance of Terms & Conditions before use (GUI)."""
     terms_file = terms_path()
     if terms_file.exists():
@@ -71,6 +71,7 @@ def ensure_terms_acceptance_gui(messagebox) -> bool:
     accepted = messagebox.askyesno(
         "Terms & Conditions",
         f"{TERMS_TEXT}\n\nDo you accept the Terms & Conditions?",
+        parent=parent,
     )
     if not accepted:
         return False


### PR DESCRIPTION
### Motivation
- The splash screen was shown but the main GUI window could be hidden while the Terms dialog steals focus, causing the application UI not to appear to the user.
- The messagebox prompt needs to be parented to the main window for reliable focus and modality across platforms.

### Description
- Updated `ensure_terms_acceptance_gui` in `void/terms.py` to accept an optional `parent` parameter and pass it to `messagebox.askyesno` for proper parenting.
- In `void/gui.py` the GUI is deiconified and `self.root.update_idletasks()` is called before invoking `ensure_terms_acceptance_gui(parent=self.root)` so the main window is visible when the prompt appears.
- This change ensures the main UI is shown prior to the Terms & Conditions prompt and the dialog is properly attached to the application window.

### Testing
- No automated tests were executed for this change.
- Repository operations (file edits and commit) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f34ff176c832b91c83014971f7080)