### PR TITLE
Add bootstrap installer for Android platform tools and auto-resolve bundled adb/fastboot

### DIFF
--- a/void/config.py
+++ b/void/config.py
@@ -66,6 +66,8 @@ class Config:
     REPORTS_DIR = BASE_DIR / "reports"
     MONITOR_DIR = BASE_DIR / "monitoring"
     SCRIPTS_DIR = BASE_DIR / "scripts"
+    TOOLS_DIR = BASE_DIR / "tools"
+    ANDROID_PLATFORM_TOOLS_DIR = TOOLS_DIR / "platform-tools"
 
     # Security
     MAX_INPUT_LENGTH = 256
@@ -118,6 +120,7 @@ class Config:
             cls.REPORTS_DIR,
             cls.MONITOR_DIR,
             cls.SCRIPTS_DIR,
+            cls.TOOLS_DIR,
         ]:
             path.mkdir(parents=True, exist_ok=True)
 

--- a/void/core/tools/__init__.py
+++ b/void/core/tools/__init__.py
@@ -6,6 +6,7 @@ from .android import (
     android_driver_hints,
     check_android_tools,
     check_usb_debugging_status,
+    install_android_platform_tools,
     resolve_android_fallback,
 )
 from .mediatek import (
@@ -20,6 +21,7 @@ __all__ = [
     "android_driver_hints",
     "check_android_tools",
     "check_usb_debugging_status",
+    "install_android_platform_tools",
     "check_mediatek_tools",
     "check_qualcomm_tools",
     "resolve_android_fallback",

--- a/void/core/tools/android.py
+++ b/void/core/tools/android.py
@@ -3,15 +3,25 @@
 from __future__ import annotations
 
 import platform
+import shutil
+import urllib.request
+import zipfile
+from pathlib import Path
 
 from .base import ToolSpec, check_tool_specs, first_available
 from ..utils import SafeSubprocess, ToolCheckResult
+from ...config import Config
 
 
 ADB_SPEC = ToolSpec(name="adb", version_args=("version",), label="ADB")
 FASTBOOT_SPEC = ToolSpec(name="fastboot", version_args=("--version",), label="Fastboot")
 ANDROID_PLATFORM_TOOLS_URL = "https://developer.android.com/tools/releases/platform-tools"
 ANDROID_DEV_OPTIONS_URL = "https://developer.android.com/studio/debug/dev-options"
+ANDROID_PLATFORM_TOOLS_ARCHIVES = {
+    "windows": "https://dl.google.com/android/repository/platform-tools-latest-windows.zip",
+    "darwin": "https://dl.google.com/android/repository/platform-tools-latest-darwin.zip",
+    "linux": "https://dl.google.com/android/repository/platform-tools-latest-linux.zip",
+}
 
 
 def check_android_tools() -> list[ToolCheckResult]:
@@ -19,11 +29,95 @@ def check_android_tools() -> list[ToolCheckResult]:
     return check_tool_specs((ADB_SPEC, FASTBOOT_SPEC))
 
 
+def install_android_platform_tools(force: bool = False) -> dict[str, object]:
+    """Download and install Android platform tools into the Void tools directory."""
+    system = platform.system().lower()
+    archive_url = ANDROID_PLATFORM_TOOLS_ARCHIVES.get(system)
+    if not archive_url:
+        return {
+            "status": "fail",
+            "message": "Unsupported OS for automatic platform tools install.",
+            "detail": f"Detected OS: {system}",
+            "links": [
+                {"label": "Download Android platform tools", "url": ANDROID_PLATFORM_TOOLS_URL},
+            ],
+        }
+
+    target_dir = Config.ANDROID_PLATFORM_TOOLS_DIR
+    adb_path = _platform_tool_path("adb")
+    fastboot_path = _platform_tool_path("fastboot")
+    if not force and adb_path.exists() and fastboot_path.exists():
+        return {
+            "status": "pass",
+            "message": "Android platform tools already installed.",
+            "detail": f"Found in {target_dir}",
+            "links": [],
+        }
+
+    Config.ensure_directories()
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    archive_path = Config.CACHE_DIR / f"platform-tools-{system}.zip"
+    try:
+        with urllib.request.urlopen(archive_url, timeout=Config.TIMEOUT_LONG) as response:
+            with archive_path.open("wb") as handle:
+                shutil.copyfileobj(response, handle)
+    except Exception as exc:
+        return {
+            "status": "fail",
+            "message": "Failed to download Android platform tools.",
+            "detail": str(exc),
+            "links": [
+                {"label": "Download Android platform tools", "url": ANDROID_PLATFORM_TOOLS_URL},
+            ],
+        }
+
+    try:
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        with zipfile.ZipFile(archive_path) as archive:
+            archive.extractall(target_dir.parent)
+    except Exception as exc:
+        return {
+            "status": "fail",
+            "message": "Failed to extract Android platform tools.",
+            "detail": str(exc),
+            "links": [
+                {"label": "Download Android platform tools", "url": ANDROID_PLATFORM_TOOLS_URL},
+            ],
+        }
+    finally:
+        if archive_path.exists():
+            archive_path.unlink()
+
+    if not adb_path.exists() or not fastboot_path.exists():
+        return {
+            "status": "fail",
+            "message": "Platform tools extraction completed but binaries were not found.",
+            "detail": f"Expected in {target_dir}",
+            "links": [
+                {"label": "Download Android platform tools", "url": ANDROID_PLATFORM_TOOLS_URL},
+            ],
+        }
+
+    return {
+        "status": "pass",
+        "message": "Android platform tools installed.",
+        "detail": f"Installed in {target_dir}",
+        "links": [],
+    }
+
+
 def resolve_android_fallback() -> tuple[str | None, list[ToolCheckResult]]:
     """Return the preferred available Android tool as a fallback."""
     results = check_android_tools()
     selected = first_available(results)
     return (selected.name if selected else None, results)
+
+
+def _platform_tool_path(name: str) -> Path:
+    suffix = ".exe" if platform.system().lower() == "windows" else ""
+    return Config.ANDROID_PLATFORM_TOOLS_DIR / f"{name}{suffix}"
 
 
 def check_usb_debugging_status(


### PR DESCRIPTION
### Motivation
- Provide an option to bundle Android platform tools (ADB/Fastboot) locally so the program can operate without users hunting for external binaries.
- Automatically prefer bundled `adb`/`fastboot` when available so subprocess calls and tool checks work out-of-the-box.
- Surface an easy installer in the CLI and interactive menu for discoverability and quick setup.

### Description
- Added new config paths `TOOLS_DIR` and `ANDROID_PLATFORM_TOOLS_DIR` and ensure the tools directory is created in `Config.ensure_directories`.
- Implemented `install_android_platform_tools` in `void/core/tools/android.py` which downloads and extracts platform-tools archives per OS and added `_platform_tool_path` and archive URL mappings.
- Enhanced `void/core/utils.py` to resolve bundled `adb`/`fastboot` via `_bundled_platform_tool_path` and `resolve_tool_command`, and updated `SafeSubprocess.run` and `check_tool` to prefer bundled binaries.
- Wired a new `bootstrap` command into `void/cli.py` (catalog entry, menu item, help text and `_cmd_bootstrap`), updated the Advanced Toolbox to reference it, and exported the installer from `void/core/tools/__init__.py`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f36491d28832b825777e19ddef25e)