### PR TITLE
Defer GUI status updates to Tk main thread

### DIFF
--- a/void/gui.py
+++ b/void/gui.py
@@ -2009,12 +2009,17 @@ class VoidGUI:
                     result = func(*args)
                 summary = self._summarize_result(label, result)
                 self._log(summary)
-                self.status_var.set(summary)
+                self.root.after(0, lambda: self.status_var.set(summary))
                 if self._is_failed_result(result):
                     self._show_task_error(label, result=result)
             except Exception as exc:
                 self._log(f"{label} failed: {exc}", level="ERROR")
-                self.status_var.set(f"{label} failed. See log for details.")
+                self.root.after(
+                    0,
+                    lambda: self.status_var.set(
+                        f"{label} failed. See log for details."
+                    ),
+                )
                 self._show_task_error(label, exc=exc)
             finally:
                 self._stop_progress()


### PR DESCRIPTION
### Motivation
- Ensure all Tkinter UI mutations from background tasks are executed on the Tk main thread to avoid race conditions and intermittent crashes.
- Keep task-runner thread isolated from direct widget/variable manipulation.

### Description
- Route the task-completion status update in `_run_task` through `self.root.after(0, ...)` instead of calling `self.status_var.set` directly.
- Route the task-failure status update in `_run_task` through `self.root.after(0, ...)` to keep UI changes on the main thread.
- Existing progress emission already uses `self.root.after` via `emit_progress`, and error dialogs are invoked via `self.root.after`, keeping all UI updates on the Tk event loop.
- Changed file: `void/gui.py` (updates confined to the `_run_task` runner body).

### Testing
- No automated tests were run against this change.
- A commit was created updating `void/gui.py` and the change is ready for review and integration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f4247194c832badc0920c5f4b5a3c)