### PR TITLE
Sanitize device IDs in backup and report names

### DIFF
--- a/void/core/backup.py
+++ b/void/core/backup.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
@@ -16,6 +17,11 @@ class AutoBackup:
     """Automated backup system"""
 
     @staticmethod
+    def _sanitize_device_id(device_id: str) -> str:
+        safe_id = re.sub(r'[^A-Za-z0-9]+', '_', device_id).strip('_')
+        return safe_id or "unknown"
+
+    @staticmethod
     def create_backup(
         device_id: str,
         backup_type: str = 'full',
@@ -23,7 +29,8 @@ class AutoBackup:
     ) -> Dict[str, Any]:
         """Create automated backup"""
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        backup_name = f"backup_{device_id}_{timestamp}"
+        safe_device_id = AutoBackup._sanitize_device_id(device_id)
+        backup_name = f"backup_{safe_device_id}_{timestamp}"
         backup_path = Config.BACKUP_DIR / backup_name
         backup_path.mkdir(parents=True, exist_ok=True)
 

--- a/void/core/report.py
+++ b/void/core/report.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import html
 import json
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
@@ -20,13 +21,19 @@ class ReportGenerator:
     """Automated report generation"""
 
     @staticmethod
+    def _sanitize_device_id(device_id: str) -> str:
+        safe_id = re.sub(r'[^A-Za-z0-9]+', '_', device_id).strip('_')
+        return safe_id or "unknown"
+
+    @staticmethod
     def generate_device_report(
         device_id: str,
         progress_callback: Optional[Callable[[str], None]] = None,
     ) -> Dict[str, Any]:
         """Generate comprehensive device report"""
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        report_name = f"device_report_{device_id}_{timestamp}"
+        safe_device_id = ReportGenerator._sanitize_device_id(device_id)
+        report_name = f"device_report_{safe_device_id}_{timestamp}"
         report_dir = Config.REPORTS_DIR / report_name
         report_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
### Motivation
- Prevent directory traversal and unsafe filesystem names when `device_id` contains non-alphanumeric characters. 
- Ensure backup and report directories are safe and portable across platforms. 
- Avoid accidental escaping of base directories or creation of unexpected paths. 

### Description
- Added a `_sanitize_device_id` helper in `void/core/backup.py` and `void/core/report.py` that replaces non-alphanumeric characters with underscores and strips leading/trailing underscores. 
- Imported `re` and use `re.sub(r'[^A-Za-z0-9]+', '_', device_id).strip('_')` with a fallback to `"unknown"` for empty results. 
- Use the sanitized value (`safe_device_id`) when constructing `backup_name` and `report_name` so directory names are safe. 
- Kept existing behavior for creating directories and writing files unchanged aside from using sanitized names. 

### Testing
- No automated tests were run as part of this change. 
- Verified changes were applied to `void/core/backup.py` and `void/core/report.py` and committed. 
- Manual runtime or unit test execution was not performed. 
- Recommendation: add unit tests for `_sanitize_device_id` and path construction to cover edge cases (not included here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f42d594c8832b9d62126af3c2ca6e)