### PR TITLE
Guard USB detection on non-Linux platforms

### DIFF
--- a/void/core/device.py
+++ b/void/core/device.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import platform
 import re
 from typing import Any, Dict, List, Tuple
 
@@ -415,6 +416,17 @@ class DeviceDetector:
         """Detect USB devices in low-level modes (EDL/preloader/download)."""
         devices: List[Dict[str, Any]] = []
         errors: List[Dict[str, Any]] = []
+        system = platform.system()
+        if system != "Linux":
+            errors.append(
+                {
+                    "source": "usb",
+                    "code": "unsupported",
+                    "message": f"USB detection is unsupported on {system}.",
+                    "details": {"platform": system},
+                }
+            )
+            return devices, errors
         code, stdout, stderr = SafeSubprocess.run(["lsusb"])
         if code == 0:
             for line in stdout.strip().split("\n"):


### PR DESCRIPTION
### Motivation

- Avoid executing `lsusb` on unsupported platforms (e.g., macOS/Windows) which produces noisy command failures.
- Provide a clear, structured response when USB detection is not applicable instead of surfacing generic command errors.

### Description

- Imported `platform` and added a platform check inside `_detect_usb_modes` in `void/core/device.py`.
- If `platform.system()` is not `Linux`, `_detect_usb_modes` now returns an empty device list and an explicit error payload with `code: "unsupported"` and a platform-specific message.
- On Linux the existing `lsusb`-based detection remains unchanged and still uses `SafeSubprocess.run` and `_classify_usb_device`.
- No other detection paths or `_build_detection_error` behavior was modified.

### Testing

- No automated tests were executed for this change.
- Manual validation consisted of reviewing the modified function logic and the generated diff in `void/core/device.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f45c5ba80832baaff4e13ee3f217c)