### PR TITLE
Ensure `Config.setup()` runs before database initialization

### DIFF
--- a/void/core/database.py
+++ b/void/core/database.py
@@ -13,6 +13,7 @@ class Database:
     """Database management"""
 
     def __init__(self):
+        Config.setup()
         self.db_path = Config.DB_PATH
         self._init_db()
 


### PR DESCRIPTION
### Motivation
- Prevent errors when SQLite opens `Config.DB_PATH` inside `Config.BASE_DIR` which may not exist if directories are not created first.
- Avoid failures that can occur when `db = Database()` is imported before configuration directories have been set up.

### Description
- Call `Config.setup()` at the start of `Database.__init__` in `void/core/database.py` to ensure required directories are present before `sqlite3.connect` is used.
- This ensures the module-level `db = Database()` instantiation runs with `Config` prepared and reduces import-time ordering issues.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f48b17c50832b96dd6a32f9597394)