### PR TITLE
Expand Gemini assistant configurability

### DIFF
--- a/void/core/gemini.py
+++ b/void/core/gemini.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import json
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping, Sequence
 import urllib.error
 import urllib.request
 
@@ -27,14 +27,31 @@ class GeminiAgentResult:
 class GeminiAgent:
     """Gemini agent wrapper that returns responses plus an updated task list."""
 
-    def __init__(self, api_key: str, model: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str,
+        model: str | None = None,
+        api_base: str | None = None,
+        system_instruction: str | None = None,
+        extra_payload: Mapping[str, Any] | None = None,
+        generation_config: Mapping[str, Any] | None = None,
+        timeout: int | None = None,
+    ) -> None:
         self.api_key = api_key
         self.model = model or Config.GEMINI_MODEL
+        self.api_base = api_base or Config.GEMINI_API_BASE
+        self.system_instruction = system_instruction
+        self.extra_payload = dict(extra_payload or {})
+        self.generation_config = dict(generation_config or {})
+        self.timeout = timeout or Config.TIMEOUT_MEDIUM
 
     def generate(
         self,
         prompt: str,
         tasks: Iterable[dict[str, str]] | None = None,
+        history: Sequence[Mapping[str, Any]] | None = None,
+        parts: Sequence[Mapping[str, Any]] | None = None,
+        extra_payload: Mapping[str, Any] | None = None,
     ) -> GeminiAgentResult:
         prompt = (prompt or "").strip()
         if not prompt:
@@ -44,35 +61,43 @@ class GeminiAgent:
             return GeminiAgentResult(success=False, message="Gemini API key is required.")
 
         task_list = list(tasks or [])
-        system_instruction = (
-            "You are a planning agent for the Void Suite GUI. "
-            "Return ONLY JSON with keys: response (string) and tasks (array). "
-            "Each task must include title and status. "
-            "Statuses: todo, in_progress, done. "
-            "Use the provided task list as the current state and update it as needed. "
-            "Add, remove, or update tasks to achieve the user's goal."
-        )
-        task_context = json.dumps(task_list, indent=2)
-        full_prompt = (
-            f"Current tasks:\\n{task_context}\\n\\n"
-            f"User message: {prompt}"
-        )
+        full_prompt = prompt
+        if task_list:
+            task_context = json.dumps(task_list, indent=2)
+            full_prompt = (
+                f"Current tasks:\\n{task_context}\\n\\n"
+                f"User message: {prompt}"
+            )
 
-        payload = {
-            "contents": [
-                {"role": "user", "parts": [{"text": full_prompt}]},
-            ],
-            "systemInstruction": {
-                "role": "system",
-                "parts": [{"text": system_instruction}],
-            },
-            "generationConfig": {
-                "temperature": 0.2,
-                "maxOutputTokens": 1024,
-            },
+        resolved_parts = list(parts or [])
+        if not resolved_parts:
+            resolved_parts = [{"text": full_prompt}]
+
+        contents = list(history or [])
+        contents.append({"role": "user", "parts": resolved_parts})
+
+        payload: dict[str, Any] = {
+            "contents": contents,
         }
 
-        url = f"{Config.GEMINI_API_BASE}/{self.model}:generateContent?key={self.api_key}"
+        if self.system_instruction:
+            payload["systemInstruction"] = {
+                "role": "system",
+                "parts": [{"text": self.system_instruction}],
+            }
+
+        generation_config = {
+            "temperature": 0.2,
+            "maxOutputTokens": 2048,
+            **self.generation_config,
+        }
+        if generation_config:
+            payload["generationConfig"] = generation_config
+
+        payload = self._merge_payload(payload, self.extra_payload)
+        payload = self._merge_payload(payload, extra_payload)
+
+        url = f"{self.api_base}/{self.model}:generateContent?key={self.api_key}"
 
         try:
             request = urllib.request.Request(
@@ -81,7 +106,7 @@ class GeminiAgent:
                 headers={"Content-Type": "application/json"},
                 method="POST",
             )
-            with urllib.request.urlopen(request, timeout=Config.TIMEOUT_MEDIUM) as response:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
                 raw_response = response.read().decode("utf-8")
         except urllib.error.URLError as exc:
             return GeminiAgentResult(
@@ -92,24 +117,39 @@ class GeminiAgent:
 
         try:
             parsed = json.loads(raw_response)
-            content = parsed["candidates"][0]["content"]["parts"][0]["text"]
-            structured = json.loads(content)
-        except (KeyError, IndexError, json.JSONDecodeError, TypeError) as exc:
+        except json.JSONDecodeError as exc:
             return GeminiAgentResult(
                 success=False,
                 message="Gemini response could not be parsed.",
                 raw={"error": str(exc), "raw": raw_response},
             )
 
-        response_text = str(structured.get("response") or "")
-        tasks_payload = structured.get("tasks") or []
-        normalized_tasks = self._normalize_tasks(tasks_payload)
+        candidate = (parsed.get("candidates") or [{}])[0]
+        content = candidate.get("content") or {}
+        parts_payload = content.get("parts") or []
+        response_text = self._extract_text(parts_payload)
+
+        structured = None
+        normalized_tasks: list[dict[str, str]] = []
+        if response_text:
+            try:
+                structured_payload = json.loads(response_text)
+                if isinstance(structured_payload, dict):
+                    structured = structured_payload
+            except json.JSONDecodeError:
+                structured = None
+
+        if structured:
+            response_text = str(structured.get("response") or response_text or "")
+            tasks_payload = structured.get("tasks") or []
+            normalized_tasks = self._normalize_tasks(tasks_payload)
+
         return GeminiAgentResult(
             success=True,
             message="Gemini response received.",
-            response=response_text,
+            response=response_text or "",
             tasks=normalized_tasks,
-            raw=structured,
+            raw={"response": parsed, "structured": structured},
         )
 
     def _normalize_tasks(self, tasks: Iterable[Any]) -> list[dict[str, str]]:
@@ -125,3 +165,29 @@ class GeminiAgent:
                 status = "todo"
             normalized.append({"title": title, "status": status})
         return normalized
+
+    def _extract_text(self, parts: Iterable[Mapping[str, Any]]) -> str:
+        chunks: list[str] = []
+        for part in parts:
+            text = part.get("text") if isinstance(part, Mapping) else None
+            if text:
+                chunks.append(str(text))
+        return "".join(chunks).strip()
+
+    def _merge_payload(
+        self,
+        base: dict[str, Any],
+        override: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        if not override:
+            return base
+        merged = dict(base)
+        for key, value in override.items():
+            if value is None:
+                merged.pop(key, None)
+                continue
+            if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+                merged[key] = self._merge_payload(dict(merged[key]), value)
+            else:
+                merged[key] = value
+        return merged


### PR DESCRIPTION
### Motivation
- Enable richer control over Gemini requests from the application by allowing system instructions, history, and payload overrides to be provided to the agent.
- Allow configuring the Gemini API endpoint and advanced generation/payload fields from the GUI to support non-default deployments and experimentation.
- Improve robustness of parsing Gemini responses by extracting text parts and optionally decoding structured JSON payloads with task updates.

### Description
- Extend `GeminiAgent` in `void/core/gemini.py` to accept `api_base`, `system_instruction`, `extra_payload`, `generation_config`, `timeout`, and to accept `history`, `parts`, and `extra_payload` in `generate` calls.
- Build request `payload` from `history`/`parts` and merge overrides with a new `_merge_payload` helper, and extract response text via `_extract_text` before attempting JSON decode.
- Add GUI variables and widgets in `void/gui.py` for `gemini_api_base`, `systemInstruction`, `generationConfig`, and `extraPayload`, plus parsing and save handlers and wiring of these advanced settings into runtime `GeminiAgent` instantiation.
- Increase default `maxOutputTokens` and wire `timeout` usage when performing the HTTP request to Gemini.

### Testing
- No automated tests were executed for these changes.
- Changes were committed to the repository and the modified files are `void/core/gemini.py` and `void/gui.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f4baf0a54832b990a1e4b84ffed1e)