### PR TITLE
Load app config before Gemini settings

### DIFF
--- a/void/gui.py
+++ b/void/gui.py
@@ -188,6 +188,7 @@ class VoidGUI:
         self.assistant_status_var = tk.StringVar(value="Gemini assistant idle.")
         self.assistant_task_list: Optional[tk.Listbox] = None
         self.assistant_tasks: List[Dict[str, str]] = []
+        self._app_config: Dict[str, Any] = self._load_app_config()
         self.gemini_api_key = str(self._app_config.get("gemini_api_key", "") or "")
         self.gemini_model_var = tk.StringVar(
             value=str(self._app_config.get("gemini_model", Config.GEMINI_MODEL))
@@ -206,7 +207,6 @@ class VoidGUI:
         self._splash_canvas: Optional[tk.Canvas] = None
         self._splash_step = 0
         self._splash_total_frames = 48
-        self._app_config: Dict[str, Any] = self._load_app_config()
         self._pending_troubleshooting_open = False
         self.output: Optional[scrolledtext.ScrolledText] = None
         self._pending_log_entries: List[str] = []


### PR DESCRIPTION
### Motivation

- Ensure saved Gemini settings from the app config are applied at startup instead of falling back to defaults.
- Prevent initialization of Gemini-related variables from reading an unpopulated `_app_config` which caused lost user values.

### Description

- Move the call to `_load_app_config()` earlier in `VoidGUI.__init__` so `_app_config` is populated before any Gemini variables are initialized.
- Initialize `gemini_api_key`, `gemini_model_var`, `gemini_api_base_var`, and advanced Gemini settings after `_app_config` is available so saved values are used.
- Remove the duplicate later `_load_app_config()` call to avoid reloading and potential inconsistencies.
- This makes values from `Config.read_config()` feed into `gemini_model_var` and `gemini_api_base_var` at startup.

### Testing

- No automated tests were run against this change.
- Static inspection and a local commit were performed to verify the diff applied cleanly.
- The change is limited and aims to be behavior-preserving aside from loading stored config values.
- Recommend running the existing test suite or a manual startup to confirm persisted Gemini settings load as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f4e1a9388832b9567c728d679917b)