### PR TITLE
Add Playwright-based browser automation and Browser GUI tab

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 
 [project.optional-dependencies]
 advanced = []
-gui = []
+gui = ["playwright"]
 
 [project.scripts]
 void = "void.main:main"

--- a/void/core/browser.py
+++ b/void/core/browser.py
@@ -1,0 +1,87 @@
+"""
+Browser automation wrapper built on Playwright.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import importlib.util
+from pathlib import Path
+from typing import Optional
+
+
+class BrowserAutomation:
+    """Simple wrapper around Playwright for GUI-driven automation."""
+
+    def __init__(self, headless: bool = False, browser_name: str = "chromium") -> None:
+        self.headless = headless
+        self.browser_name = browser_name
+        self._playwright = None
+        self._browser = None
+        self._context = None
+        self._page = None
+        self._sync_playwright = self._resolve_playwright()
+
+    @property
+    def is_active(self) -> bool:
+        return self._page is not None
+
+    def launch(self) -> None:
+        if self.is_active:
+            return
+        self._playwright = self._sync_playwright().start()
+        browser_type = getattr(self._playwright, self.browser_name, None)
+        if browser_type is None:
+            raise RuntimeError(f"Unsupported browser type: {self.browser_name}")
+        self._browser = browser_type.launch(headless=self.headless)
+        self._context = self._browser.new_context()
+        self._page = self._context.new_page()
+
+    def open(self, url: str) -> None:
+        page = self._require_page()
+        page.goto(url)
+
+    def click(self, x: int, y: int) -> None:
+        page = self._require_page()
+        page.mouse.click(x, y)
+
+    def type(self, text: str) -> None:
+        page = self._require_page()
+        page.keyboard.type(text)
+
+    def screenshot(self, path: Optional[str] = None) -> str:
+        page = self._require_page()
+        if not path:
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            path = f"browser_screenshot_{timestamp}.png"
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        page.screenshot(path=str(target), full_page=True)
+        return str(target)
+
+    def close(self) -> None:
+        if self._context:
+            self._context.close()
+        if self._browser:
+            self._browser.close()
+        if self._playwright:
+            self._playwright.stop()
+        self._playwright = None
+        self._browser = None
+        self._context = None
+        self._page = None
+
+    def _require_page(self):
+        if not self._page:
+            raise RuntimeError("Browser not launched. Call launch() first.")
+        return self._page
+
+    def _resolve_playwright(self):
+        if importlib.util.find_spec("playwright") is None:
+            raise RuntimeError(
+                "Playwright is not installed. Run 'pip install playwright' and "
+                "'playwright install' to enable browser automation."
+            )
+        from playwright.sync_api import sync_playwright
+
+        return sync_playwright


### PR DESCRIPTION
### Motivation
- Provide a programmatic headed browser that the assistant can drive for navigation and input.
- Expose simple browser actions (open, click, type, screenshot) to the GUI and the Gemini assistant.
- Surface browser controls and action logs in the GUI so operators can supervise automated actions.
- Require explicit confirmations before any automated action that could modify external state.

### Description
- Added `void/core/browser.py` implementing `BrowserAutomation` as a small Playwright-based wrapper with `launch`, `open`, `click`, `type`, `screenshot`, and `close` APIs and a check that Playwright is installed.
- Integrated a new "Browser" tab in `void/gui.py` with controls for launching/closing the browser, navigating to a URL, clicking by X/Y coordinates, typing text, taking screenshots, an action log, and a confirmation toggle.
- Wired Gemini responses into the GUI via `_handle_gemini_result` and `_dispatch_browser_command` so structured assistant outputs like `browser_action`/`browser_actions` can cause browser operations (subject to confirmation).
- Added Playwright to the optional `gui` extras in `pyproject.toml` and implemented user-facing safety prompts and logging for automated browser actions.

### Testing
- No automated tests were run against these changes as part of this rollout.
- The changes are GUI- and environment-dependent (Playwright and a headed display) and were not executed in this environment.
- Static edits were committed and basic import wiring was performed, but no CI or unit test suite was invoked.
- Manual runtime validation is recommended on a desktop environment with Playwright installed and `playwright install` executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f4f8948e8832bbe2c619195aac813)