### PR TITLE
Enhance Gemini assistant memory handling

### DIFF
--- a/void/config.py
+++ b/void/config.py
@@ -87,6 +87,7 @@ class Config:
     # Gemini assistant (GUI)
     GEMINI_MODEL = "gemini-1.5-flash"
     GEMINI_API_BASE = "https://generativelanguage.googleapis.com/v1beta/models"
+    GEMINI_HISTORY_LIMIT = 24
 
     # Privacy controls
     COLLECT_IMEI = True

--- a/void/core/gemini.py
+++ b/void/core/gemini.py
@@ -73,7 +73,7 @@ class GeminiAgent:
         if not resolved_parts:
             resolved_parts = [{"text": full_prompt}]
 
-        contents = list(history or [])
+        contents = self._build_history(history)
         contents.append({"role": "user", "parts": resolved_parts})
 
         payload: dict[str, Any] = {
@@ -173,6 +173,20 @@ class GeminiAgent:
             if text:
                 chunks.append(str(text))
         return "".join(chunks).strip()
+
+    def _build_history(
+        self,
+        history: Sequence[Mapping[str, Any]] | None,
+    ) -> list[Mapping[str, Any]]:
+        if not history:
+            return []
+        limit = max(0, int(Config.GEMINI_HISTORY_LIMIT))
+        if limit <= 0:
+            return []
+        history_list = list(history)
+        if len(history_list) > limit:
+            history_list = history_list[-limit:]
+        return history_list
 
     def _merge_payload(
         self,


### PR DESCRIPTION
### Motivation
- Improve the Gemini assistant’s conversational continuity by preserving recent chat history across exchanges.
- Make the retained history configurable to bound payload size and limit sensitive state exposure.
- Ensure the GUI records user and model turns so requests to Gemini include contextual data.
- Provide a simple trimming policy to avoid sending unbounded history to the API.

### Description
- Add a new configuration option `GEMINI_HISTORY_LIMIT` to `Config` with a default of `24`.
- Implement `GeminiAgent._build_history(...)` and use it in `GeminiAgent.generate(...)` to trim incoming `history` to the configured limit.
- Add `assistant_history` storage to `VoidGUI`, clear it when tasks are cleared, and append user/model turns via `_append_assistant_history`.
- Pass `assistant_history` into `GeminiAgent.generate(...)` when sending messages from the GUI so the agent receives recent conversation context.

### Testing
- No automated tests were executed for this change.
- Unit tests: none run.
- Integration tests: none run.
- Lint/static checks: not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f510cebb0832bb0ea673c2ca4188b)