### PR TITLE
Fix tool check labels for asset checklist

### DIFF
--- a/void/core/tools/base.py
+++ b/void/core/tools/base.py
@@ -19,7 +19,8 @@ class ToolSpec:
 
 def check_tool_spec(spec: ToolSpec) -> ToolCheckResult:
     """Validate a tool spec."""
-    return check_tool(spec.name, spec.version_args or None)
+    label = spec.label or spec.name
+    return check_tool(spec.name, spec.version_args or None, label=label)
 
 
 def check_tool_specs(specs: Iterable[ToolSpec]) -> list[ToolCheckResult]:

--- a/void/core/utils.py
+++ b/void/core/utils.py
@@ -37,6 +37,7 @@ class ToolCheckResult:
     """Result of validating an external tool."""
 
     name: str
+    label: str | None = None
     available: bool
     path: str | None = None
     version: str | None = None
@@ -68,7 +69,12 @@ def resolve_tool_command(cmd: List[str]) -> List[str]:
     return cmd
 
 
-def check_tool(name: str, version_args: Sequence[str] | None = None) -> ToolCheckResult:
+def check_tool(
+    name: str,
+    version_args: Sequence[str] | None = None,
+    *,
+    label: str | None = None,
+) -> ToolCheckResult:
     """Validate a tool is on PATH and optionally resolve its version."""
     path = shutil.which(name)
     bundled_path = _bundled_platform_tool_path(name)
@@ -77,6 +83,7 @@ def check_tool(name: str, version_args: Sequence[str] | None = None) -> ToolChec
     if not path:
         return ToolCheckResult(
             name=name,
+            label=label,
             available=False,
             error={
                 "code": "tool_missing",
@@ -99,6 +106,7 @@ def check_tool(name: str, version_args: Sequence[str] | None = None) -> ToolChec
 
     return ToolCheckResult(
         name=name,
+        label=label,
         available=True,
         path=path,
         version=version,


### PR DESCRIPTION
### Motivation
- Fix an `AttributeError` in the asset checklist where `collect_required_assets` expects a `label` on tool check results. 
- Ensure UI shows human-friendly tool names (e.g. `ADB`, `Fastboot`) instead of raw tool identifiers. 
- Propagate labels from tool specs into the results so download/checklist messages are clear.

### Description
- Add an optional `label` field to the `ToolCheckResult` dataclass in `void/core/utils.py`.
- Update `check_tool` to accept a `label` keyword argument and populate it on returned `ToolCheckResult` instances.
- Propagate `ToolSpec.label` via `check_tool_spec` in `void/core/tools/base.py` by passing `label=spec.label or spec.name` to `check_tool`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f54af82b8832bb405171cec638b10)