### PR TITLE
Fix dataclass field order in ToolCheckResult to avoid import TypeError

### DIFF
--- a/void/core/utils.py
+++ b/void/core/utils.py
@@ -37,8 +37,8 @@ class ToolCheckResult:
     """Result of validating an external tool."""
 
     name: str
-    label: str | None = None
     available: bool
+    label: str | None = None
     path: str | None = None
     version: str | None = None
     error: dict[str, str] = field(default_factory=dict)


### PR DESCRIPTION
### Motivation
- Importing the package raised a `TypeError` because a non-default dataclass field followed a defaulted one in `ToolCheckResult`.
- The failure occurred during startup when the `void` CLI attempted to import `void.core.utils` and instantiate dataclasses.
- Dataclasses require all non-default fields to come before fields with default values to be valid across Python versions.
- Reordering the fields prevents the runtime crash and restores normal startup behavior.

### Description
- Reordered the fields of `ToolCheckResult` in `void/core/utils.py` so the non-default `available` field precedes the defaulted `label` field.
- Kept the dataclass frozen and preserved all existing attributes: `name`, `available`, `label`, `path`, `version`, and `error`.
- No other logic or behavior was changed beyond the field reordering.
- This is a minimal compatibility fix to satisfy dataclass initialization rules.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f56e0b168832b8d2044c9af9192fc)