### PR TITLE
Handle missing device metadata for backups and reports

### DIFF
--- a/void/core/backup.py
+++ b/void/core/backup.py
@@ -45,7 +45,14 @@ class AutoBackup:
         # Backup device info
         info_file = backup_path / "device_info.json"
         devices, _ = DeviceDetector.detect_all()
-        device_info = next((d for d in devices if d['id'] == device_id), {})
+        device_info = next((d for d in devices if d.get('id') == device_id), {})
+        if not device_info:
+            logger.log(
+                'warning',
+                'backup',
+                f'Device metadata could not be resolved for {device_id}.',
+                device_id=device_id,
+            )
         with open(info_file, 'w') as f:
             json.dump(device_info, f, indent=2, default=str)
         backed_up.append('device_info')

--- a/void/core/report.py
+++ b/void/core/report.py
@@ -48,7 +48,14 @@ class ReportGenerator:
         if progress_callback:
             progress_callback("Collecting device info...")
         devices, _ = DeviceDetector.detect_all()
-        device_info = next((d for d in devices if d['id'] == device_id), {})
+        device_info = next((d for d in devices if d.get('id') == device_id), {})
+        if not device_info:
+            logger.log(
+                'warning',
+                'report',
+                f'Device metadata could not be resolved for {device_id}.',
+                device_id=device_id,
+            )
         report['sections']['device_info'] = device_info
 
         # Performance analysis


### PR DESCRIPTION
### Motivation
- Prevent exceptions when device metadata entries lack an `id` key during backup and report generation.  
- Avoid breaking behavior by keeping `device_info` as an empty object when a matching device cannot be resolved.  
- Surface the issue via a warning log so unresolved metadata is visible to operators.

### Description
- Change device matching to use `d.get("id")` instead of `d['id']` in `AutoBackup.create_backup` (`void/core/backup.py`).  
- Apply the same change in `ReportGenerator.generate_device_report` (`void/core/report.py`).  
- Add `logger.log('warning', ...)` when no device metadata is found while leaving `device_info` as `{}`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695206fc7544832ba51c320e3a97b14e)