### PR TITLE
Handle logcat startup failures gracefully

### DIFF
--- a/void/core/logcat.py
+++ b/void/core/logcat.py
@@ -26,13 +26,22 @@ class LogcatViewer:
         if filter_tag:
             cmd.extend(['-s', filter_tag])
 
+        try:
+            self.process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except (FileNotFoundError, OSError) as exc:
+            self.process = None
+            self.running = False
+            logger.log('error', 'logcat', f'Failed to start logcat: {exc}')
+            if progress_callback:
+                progress_callback("Logcat failed to start.")
+            return
+
         self.running = True
-        self.process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        )
 
         logger.log('info', 'logcat', 'Logcat started')
         if progress_callback:


### PR DESCRIPTION
### Motivation
- Prevent leaving `LogcatViewer` in a running state when the `adb logcat` subprocess fails to start.
- Provide a clear, logged error message when `adb` is not available or the subprocess start fails.
- Ensure progress callbacks receive failure notifications instead of misleading success messages.

### Description
- Wrap the `subprocess.Popen` call in a `try/except (FileNotFoundError, OSError)` block to catch startup failures.
- On exception, set `self.process = None` and `self.running = False`, log an error via `logger.log`, and call the progress callback with a failure message.
- Move setting of `self.running = True` to after the `Popen` call succeeds so the viewer state remains consistent.
- Preserve existing behavior on success by logging `Logcat started` and calling the streaming progress callback.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69520c203614832b801383c9cc19edb7)