### PR TITLE
Add Problem Categories diagnostics to Dashboard

### DIFF
--- a/void/core/startup.py
+++ b/void/core/startup.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from .utils import SafeSubprocess
+
+
+class StartupWizardAnalyzer:
+    """Detect startup wizard state on a connected Android device."""
+
+    _PACKAGE_CANDIDATES = [
+        "com.google.android.setupwizard",
+        "com.android.setupwizard",
+        "com.samsung.android.setupwizard",
+        "com.sec.android.app.setupwizard",
+        "com.htc.android.setupwizard",
+        "com.motorola.setup",
+        "com.motorola.setupwizard",
+    ]
+
+    @staticmethod
+    def _parse_setting(raw: str) -> Optional[bool]:
+        value = raw.strip().lower()
+        if value in {"1", "true", "yes"}:
+            return True
+        if value in {"0", "false", "no"}:
+            return False
+        return None
+
+    @staticmethod
+    def analyze(device_id: str) -> Dict[str, Any]:
+        result: Dict[str, Any] = {
+            "running": False,
+            "active_package": None,
+            "pid": None,
+            "top_activity": None,
+            "setup_complete": None,
+            "device_provisioned": None,
+            "installed_packages": [],
+        }
+
+        code, stdout, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "pm", "list", "packages"]
+        )
+        installed = []
+        if code == 0:
+            for line in stdout.splitlines():
+                if not line.startswith("package:"):
+                    continue
+                package = line.split("package:", 1)[-1].strip()
+                if package in StartupWizardAnalyzer._PACKAGE_CANDIDATES:
+                    installed.append(package)
+        result["installed_packages"] = installed
+
+        for package in installed or StartupWizardAnalyzer._PACKAGE_CANDIDATES:
+            code, stdout, _ = SafeSubprocess.run(
+                ["adb", "-s", device_id, "shell", "pidof", package]
+            )
+            if code == 0 and stdout.strip():
+                result["running"] = True
+                result["active_package"] = package
+                result["pid"] = stdout.strip()
+                break
+
+        code, stdout, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "dumpsys", "activity", "activities"]
+        )
+        if code == 0:
+            for line in stdout.splitlines():
+                if not any(
+                    key in line
+                    for key in ("mResumedActivity", "topResumedActivity", "mFocusedActivity")
+                ):
+                    continue
+                if any(package in line for package in StartupWizardAnalyzer._PACKAGE_CANDIDATES):
+                    result["top_activity"] = line.strip()
+                    if result["active_package"] is None:
+                        match = re.search(r"(com\.[\w.]+setupwizard\w*)", line)
+                        if match:
+                            result["active_package"] = match.group(1)
+                        else:
+                            result["active_package"] = next(
+                                (pkg for pkg in StartupWizardAnalyzer._PACKAGE_CANDIDATES if pkg in line),
+                                None,
+                            )
+                        result["running"] = True
+                    break
+
+        code, stdout, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "settings", "get", "secure", "user_setup_complete"]
+        )
+        if code == 0:
+            result["setup_complete"] = StartupWizardAnalyzer._parse_setting(stdout)
+
+        code, stdout, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "settings", "get", "global", "device_provisioned"]
+        )
+        if code == 0:
+            result["device_provisioned"] = StartupWizardAnalyzer._parse_setting(stdout)
+
+        return result


### PR DESCRIPTION
### Motivation
- Provide quick, focused diagnostic actions in the Dashboard for common problem areas so operators can run targeted checks quickly.
- Surface concise category summaries in the device details area and stream detailed lines to the Operations Log for easier triage.
- Reuse existing analyzers where possible and add detection for startup wizard state to cover setup/provisioning issues.

### Description
- Added a new Dashboard card `Problem Categories` with buttons for `Startup Wizard`, `Network`, `Display`, and `Backup` that call a unified handler `._run_problem_category`.
- Implemented per-category analyzer adapters on `VoidGUI`: `_analyze_network_category`, `_analyze_display_category`, `_analyze_backup_category`, and `_analyze_startup_wizard_category` which call `NetworkAnalyzer.analyze`, `DisplayAnalyzer.analyze`, `AutoBackup.list_backups`/`shutil.disk_usage`, and the new `StartupWizardAnalyzer.analyze` respectively.
- Added a new startup analyzer module at `void/core/startup.py` implementing `StartupWizardAnalyzer.analyze` to detect installed/running setup wizard packages, top activity, and `settings` flags (`user_setup_complete`, `device_provisioned`).
- Updated UI to include a `categories` device detail section and to log category detail lines to the Operations Log via `._log` and display a summary via `._set_device_section("categories", ...)`.

### Testing
- No automated tests were executed as part of this change.
- Basic manual integration was implemented in the GUI wiring (UI elements, callbacks, and analyzers) but no unit test suite changes were run.
- Existing diagnostic flows (`NetworkAnalyzer`, `DisplayAnalyzer`, `AutoBackup`) are invoked by the new adapters and rely on their current behavior; no new test automation was added for `StartupWizardAnalyzer`.
- Recommend running the GUI and exercising each `Problem Categories` button against a connected device to validate behavior and logging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521926a68c832bbc60ddf3720cac1d)