### PR TITLE
Add setup wizard diagnostics to scans and dashboard

### DIFF
--- a/void/core/setup_wizard.py
+++ b/void/core/setup_wizard.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from .utils import SafeSubprocess
+
+
+@dataclass
+class SetupWizardDiagnostics:
+    """Collect boot/setup wizard diagnostics for a connected Android device."""
+
+    _PACKAGE_CANDIDATES = (
+        "com.google.android.setupwizard",
+        "com.android.setupwizard",
+        "com.samsung.android.setupwizard",
+        "com.sec.android.app.setupwizard",
+        "com.htc.android.setupwizard",
+        "com.motorola.setup",
+        "com.motorola.setupwizard",
+    )
+
+    @staticmethod
+    def _parse_setting(raw: str) -> Optional[bool]:
+        value = raw.strip().lower()
+        if value in {"1", "true", "yes"}:
+            return True
+        if value in {"0", "false", "no"}:
+            return False
+        return None
+
+    @staticmethod
+    def _parse_boot_completed(raw: str) -> Optional[bool]:
+        value = raw.strip().lower()
+        if value in {"1", "y", "yes", "true"}:
+            return True
+        if value in {"0", "n", "no", "false"}:
+            return False
+        return None
+
+    @classmethod
+    def _detect_resumed_activity(cls, device_id: str) -> Optional[str]:
+        code, stdout, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "dumpsys", "activity", "activities"]
+        )
+        if code != 0:
+            return None
+
+        for line in stdout.splitlines():
+            if not any(
+                key in line
+                for key in ("mResumedActivity", "topResumedActivity", "mFocusedActivity")
+            ):
+                continue
+            return line.strip()
+        return None
+
+    @classmethod
+    def _detect_setup_packages(cls, device_id: str) -> List[str]:
+        code, stdout, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "cmd", "package", "list", "packages"]
+        )
+        if code != 0:
+            return []
+        packages = []
+        for line in stdout.splitlines():
+            if not line.startswith("package:"):
+                continue
+            package = line.split("package:", 1)[-1].strip()
+            if package in cls._PACKAGE_CANDIDATES or "setupwizard" in package:
+                packages.append(package)
+        return packages
+
+    @classmethod
+    def _detect_wizard_activity(cls, activity_line: Optional[str]) -> Optional[str]:
+        if not activity_line:
+            return None
+        if any(package in activity_line for package in cls._PACKAGE_CANDIDATES):
+            match = re.search(r"(com\.[\w.]+setupwizard\w*)", activity_line)
+            return match.group(1) if match else activity_line
+        return None
+
+    @classmethod
+    def analyze(cls, device_id: str) -> Dict[str, Any]:
+        boot_completed = None
+        user_setup_complete = None
+
+        code, stdout, _ = SafeSubprocess.run(
+            ["adb", "-s", device_id, "shell", "getprop", "sys.boot_completed"]
+        )
+        if code == 0:
+            boot_completed = cls._parse_boot_completed(stdout)
+
+        code, stdout, _ = SafeSubprocess.run(
+            [
+                "adb",
+                "-s",
+                device_id,
+                "shell",
+                "settings",
+                "get",
+                "secure",
+                "user_setup_complete",
+            ]
+        )
+        if code == 0:
+            user_setup_complete = cls._parse_setting(stdout)
+
+        resumed_activity = cls._detect_resumed_activity(device_id)
+        setup_packages = cls._detect_setup_packages(device_id)
+        wizard_activity = cls._detect_wizard_activity(resumed_activity)
+
+        wizard_running = False
+        if wizard_activity:
+            wizard_running = True
+        elif resumed_activity and "setupwizard" in resumed_activity.lower():
+            wizard_running = True
+
+        status = "unknown"
+        if boot_completed is False:
+            status = "boot incomplete"
+        elif boot_completed is True:
+            if wizard_running and user_setup_complete is True:
+                status = "wizard loop suspected"
+            elif user_setup_complete is False:
+                status = "setup incomplete"
+            elif wizard_running:
+                status = "wizard loop suspected"
+            elif user_setup_complete is True:
+                status = "setup complete"
+
+        return {
+            "boot_completed": boot_completed,
+            "user_setup_complete": user_setup_complete,
+            "resumed_activity": resumed_activity,
+            "setup_packages": setup_packages,
+            "wizard_activity": wizard_activity,
+            "wizard_running": wizard_running,
+            "status": status,
+        }

--- a/void/core/workflows.py
+++ b/void/core/workflows.py
@@ -10,6 +10,7 @@ from .logging import logger
 from .network import NetworkAnalyzer
 from .performance import PerformanceAnalyzer
 from .report import ReportGenerator
+from .setup_wizard import SetupWizardDiagnostics
 from .tools import check_android_tools
 from .utils import SafeSubprocess, ToolCheckResult
 
@@ -124,6 +125,7 @@ class RepairWorkflow:
         performance = PerformanceAnalyzer.analyze(self.device_id)
         network = NetworkAnalyzer.analyze(self.device_id)
         display = DisplayAnalyzer.analyze(self.device_id)
+        setup_wizard = SetupWizardDiagnostics.analyze(self.device_id)
         report_result = None
         if self.save_report:
             report_result = ReportGenerator.generate_device_report(self.device_id)
@@ -133,6 +135,7 @@ class RepairWorkflow:
             "performance": performance,
             "network": network,
             "display": display,
+            "startup_wizard": setup_wizard,
             "partitions": self._scan_partitions(init_result),
             "report": report_result,
         }


### PR DESCRIPTION
### Motivation
- Provide a focused diagnostics helper to determine whether an Android device is stuck in or has completed the setup/startup wizard sequence.
- Surface richer, structured diagnostic information in the GUI "Startup Wizard" category to aid troubleshooting.
- Include the diagnostics in workflow scans so remediation decisions can use boot/setup state.

### Description
- Add `void/core/setup_wizard.py` implementing `SetupWizardDiagnostics.analyze` which queries `adb shell getprop sys.boot_completed`, `adb shell settings get secure user_setup_complete`, resumed activity via `dumpsys activity`, and packages via `cmd package list packages` and returns a structured status (e.g. `setup incomplete`, `wizard loop suspected`, `boot incomplete`).
- Integrate diagnostics into the GUI by importing `SetupWizardDiagnostics` and augmenting the Startup Wizard category details and summary with `diagnostic status`, `boot_completed`, `user_setup_complete`, `resumed_activity`, and `setup_packages`.
- Include the diagnostics in the workflow scan results by invoking `SetupWizardDiagnostics.analyze` and adding the data under the `startup_wizard` key in the workflow `_scan` return value.
- Modified files: `void/core/setup_wizard.py` (new), `void/gui.py` (update), and `void/core/workflows.py` (update).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521cc16d00832bb5d223bcf0e47a79)